### PR TITLE
Add support for upcoming Luma3DS & B9S versions...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ INCLUDES	:=	source source/common source/font source/fs source/crypto source/fatf
 ARCH	:=	-mthumb -mthumb-interwork -flto
 
 CFLAGS	:=	-g -Wall -Wextra -Wpedantic -Wcast-align -Wno-main -O2\
-			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer -ffast-math -std=gnu99\
+			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer -ffast-math -std=gnu11\
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9

--- a/source/common/ui.h
+++ b/source/common/ui.h
@@ -52,8 +52,8 @@
 #define COLOR_STD_BG        COLOR_BLACK
 #define COLOR_STD_FONT      COLOR_WHITE
 
-#define TOP_SCREEN          (u8*)(*(u32*)0x23FFFE00)
-#define BOT_SCREEN          (u8*)(*(u32*)0x23FFFE08)
+#define TOP_SCREEN          top_screen
+#define BOT_SCREEN          bottom_screen
 
 #ifdef SWITCH_SCREENS
 #define MAIN_SCREEN         TOP_SCREEN
@@ -66,6 +66,8 @@
 #define SCREEN_WIDTH_MAIN   SCREEN_WIDTH_BOT
 #define SCREEN_WIDTH_ALT    SCREEN_WIDTH_TOP
 #endif
+
+extern u8 *top_screen, *bottom_screen;
 
 void ClearScreen(unsigned char *screen, int color);
 void ClearScreenF(bool clear_main, bool clear_alt, int color);

--- a/source/gamecart/protocol.c
+++ b/source/gamecart/protocol.c
@@ -28,8 +28,6 @@
 #define REG_AESKEYXFIFO (*(vu32*)0x10009104)
 #define REG_AESKEYYFIFO (*(vu32*)0x10009108)
 
-extern u8* bottomScreen;
-
 u32 CartID = 0xFFFFFFFFu;
 u32 CartType = 0;
 

--- a/source/main.c
+++ b/source/main.c
@@ -16,11 +16,22 @@ void PowerOff()
     while (true);
 }
 
+u8 *top_screen, *bottom_screen;
 
-void main()
+void main(int argc, char** argv)
 {
+    // Fetch the framebuffer addresses
+    if(argc >= 2) {
+        // newer entrypoints
+        u8 **fb = (u8 **)(void *)argv[2];
+        top_screen = fb[0];
+        bottom_screen = fb[2];
+    } else {
+        // outdated entrypoints
+        top_screen = (u8*)(*(u32*)0x23FFFE00);
+        bottom_screen = (u8*)(*(u32*)0x23FFFE08);
+    }
     u32 godmode_exit = GodMode();
     ClearScreenF(true, true, COLOR_STD_BG);
     (godmode_exit == GODMODE_EXIT_REBOOT) ? Reboot() : PowerOff();
-    return;
 }

--- a/source/start.s
+++ b/source/start.s
@@ -65,6 +65,13 @@ _start_gw:
     stmia r0, {r1,r2,r3}
     @ framebuffers properly set
 
+    ldr r3, =0xFFFF0830         @ flush (clean & invalidate) entire dcache b9 func
+    blx r3
+
+    mov r3, #0
+    mcr p15, 0, r3, c7, c5, 0   @ invalidate I-cache
+
+    mov r2, #0
     ldr r3, .entry
     bx r3
 
@@ -74,8 +81,16 @@ _start_gw:
 .entry:   .word 0x23F00000
 
 _skip_gw:
+    mov r9, r0      @ argc
+    mov r10, r1     @ argv
+
+    ldr r4, =0xBEEF
+    cmp r2, r4      @ magic word
+    movne r9, #0
+
     @ Disable caches / mpu
     mrc p15, 0, r4, c1, c0, 0  @ read control register
+    bic r4, #(1<<16)           @ - dtcm disable (mandated by the docs, before you change the dtcm's address)
     bic r4, #(1<<12)           @ - instruction cache disable
     bic r4, #(1<<2)            @ - data cache disable
     bic r4, #(1<<0)            @ - mpu disable
@@ -91,10 +106,10 @@ _skip_gw:
         strlt r2, [r0], #4
         blt .bss_clr
 
-    @ Flush caches
+    @ Invalidate caches
     mov r5, #0
-    mcr p15, 0, r5, c7, c5, 0  @ flush I-cache
-    mcr p15, 0, r5, c7, c6, 0  @ flush D-cache
+    mcr p15, 0, r5, c7, c5, 0  @ invalidate I-cache
+    mcr p15, 0, r5, c7, c6, 0  @ invalidate D-cache
     mcr p15, 0, r5, c7, c10, 4 @ drain write buffer
 
     @ Give read/write access to all the memory regions
@@ -144,7 +159,8 @@ _skip_gw:
 
     ldr sp, =0x23F00000
 
-    blx main
-    b _start
+    mov r0, r9
+    mov r1, r10
+    b main
 
 .pool


### PR DESCRIPTION
This commit adds support for upcoming Luma3DS & B9S versions without breaking support for outdated/deprecated entrypoints.

It additionally addresses some issues in start.s (GW relocator not clearing&relocating caches & the DTCM issue).