### PR TITLE
devkitARM r47 fix

### DIFF
--- a/source/filesys/fsscript.c
+++ b/source/filesys/fsscript.c
@@ -75,7 +75,7 @@ Gm9ScriptCmd cmd_list[] = {
     { CMD_ID_POWEROFF, "poweroff", 0, 0 }
 };    
 
-inline bool strntohex(const char* str, u8* hex, u32 len) {
+static inline bool strntohex(const char* str, u8* hex, u32 len) {
     if (!len) {
         len = strlen(str); 
         if (len%1) return false;


### PR DESCRIPTION
inline alone leaves the compiler free to use the external definition, but the program does not provide one.  