### PR TITLE
Fixed mounting images

### DIFF
--- a/source/filesys/fsinit.c
+++ b/source/filesys/fsinit.c
@@ -35,13 +35,12 @@ bool InitExtFS() {
 
 bool InitImgFS(const char* path) {
     // find drive # of the last image FAT drive
+    u32 type = IdentifyFileType(path);
     u32 drv_i = NORM_FS - IMGN_FS;
-    for (; drv_i < NORM_FS; drv_i++) {
-        char fsname[8];
-        snprintf(fsname, 7, "%lu:", drv_i);
-        if (!(DriveType(fsname)&DRV_IMAGE))
-            break;
-    }
+    if (type & IMG_NAND)
+        drv_i += IMGN_FS;
+    else
+        drv_i += 1;
     // deinit image filesystem
     DismountDriveType(DRV_IMAGE);
     // (re)mount image, done if path == NULL


### PR DESCRIPTION
This fixes mounting images (closes #142), while still allowing mounting from 8: and 9: (except for nand images).

There might be a better solution to this, but i couldn't find a way to identify the amount of needed drives and didn't know where to implement it.