### PR TITLE
Add local exception handler, improve MPcore IRQ handler

### DIFF
--- a/3ds-data
+++ b/3ds-data
@@ -1,0 +1,1 @@
+/home/wolfvak/GitHub/3ds-data/

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,12 @@ INCLUDES	:=	common source source/common source/font source/filesys source/crypto
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-mthumb -mthumb-interwork -flto
+ARCH	:=	-DARM9 -march=armv5te -mthumb -mthumb-interwork -flto
 
-CFLAGS	:=	-g -Wall -Wextra -Wpedantic -Wcast-align -Wno-main -O2\
-			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer -ffast-math -std=gnu11\
-			$(ARCH)
-
-CFLAGS	+=	$(INCLUDE) -DARM9
+ASFLAGS	:=	$(ARCH) -g -x assembler-with-cpp $(INCLUDE)
+CFLAGS	:=	$(ARCH) -g -Wall -Wextra -Wpedantic -Wcast-align -Wno-main -O2 \
+			-mtune=arm946e-s -fomit-frame-pointer -ffast-math -std=gnu11 \
+			$(INCLUDE)
 
 CFLAGS	+=	-DBUILD_NAME="\"$(TARGET) (`date +'%Y/%m/%d'`)\""
 
@@ -60,7 +59,6 @@ endif
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 
-ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-T../link.ld -nostartfiles -g $(ARCH) -Wl,-Map,$(TARGET).map
 
 LIBS	:=

--- a/common/arm.h
+++ b/common/arm.h
@@ -10,6 +10,20 @@
 #define SR_SYS_MODE (0x1F)
 #define SR_PMODE_MASK (0x1F)
 
-#define SR_THUMB  (1 << 5)
-#define SR_FIQ    (1 << 6)
-#define SR_IRQ    (1 << 7)
+#define SR_THUMB  (1<<5)
+#define SR_FIQ    (1<<6)
+#define SR_IRQ    (1<<7)
+
+#ifdef ARM9
+#define CR_ENABLE_MPU    (1<<0)
+#define CR_ENABLE_BIGEND (1<<7)
+#define CR_ENABLE_DCACHE (1<<2)
+#define CR_ENABLE_ICACHE (1<<12)
+#define CR_ENABLE_DTCM   (1<<16)
+#define CR_ENABLE_ITCM   (1<<18)
+#define CR_ALT_VECTORS   (1<<13)
+#define CR_CACHE_RROBIN  (1<<14)
+#define CR_DISABLE_TBIT  (1<<15)
+#define CR_DTCM_LMODE    (1<<17)
+#define CR_ITCM_LMODE    (1<<19)
+#endif

--- a/common/arm.h
+++ b/common/arm.h
@@ -1,0 +1,15 @@
+#pragma once
+
+/* Status Register flags */
+#define SR_USR_MODE (0x10)
+#define SR_FIQ_MODE (0x11)
+#define SR_IRQ_MODE (0x12)
+#define SR_SVC_MODE (0x13)
+#define SR_ABT_MODE (0x17)
+#define SR_UND_MODE (0x1B)
+#define SR_SYS_MODE (0x1F)
+#define SR_PMODE_MASK (0x1F)
+
+#define SR_THUMB  (1 << 5)
+#define SR_FIQ    (1 << 6)
+#define SR_IRQ    (1 << 7)

--- a/common/brf.h
+++ b/common/brf.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef ARM9
+
+/* None of these functions require a working stack */
+/* Assume R0-R3, R12 are always clobbered */
+#define BRF_INVALIDATE_DCACHE       (0xFFFF07F0)
+#define BRF_INVALIDATE_DCACHE_RANGE (0xFFFF0868)
+#define BRF_WRITEBACK_DCACHE        (0xFFFF07FC)
+#define BRF_WRITEBACK_DCACHE_RANGE  (0xFFFF0884)
+#define BRF_WB_INV_DCACHE           (0xFFFF0830)
+#define BRF_WB_INV_DCACHE_RANGE     (0xFFFF08A8)
+#define BRF_INVALIDATE_ICACHE       (0xFFFF0AB4)
+#define BRF_INVALIDATE_ICACHE_RANGE (0xFFFF0AC0)
+#define BRF_RESETCP15               (0xFFFF0C58)
+
+#else
+
+#endif

--- a/common/cpu.h
+++ b/common/cpu.h
@@ -37,7 +37,7 @@ static inline void CPU_WriteCR(u32 cr)
 static inline void CPU_DisableIRQ(void)
 {
     #ifdef ARM9
-    CPU_WriteCPSR_c(CPU_ReadCPSR() | (0xC0));
+    CPU_WriteCPSR_c(CPU_ReadCPSR() | (SR_IRQ | SR_FIQ));
     #else
     asm("cpsid if\n\t");
     #endif
@@ -47,7 +47,7 @@ static inline void CPU_DisableIRQ(void)
 static inline void CPU_EnableIRQ(void)
 {
     #ifdef ARM9
-    CPU_WriteCPSR_c(CPU_ReadCPSR() & ~(0xC0));
+    CPU_WriteCPSR_c(CPU_ReadCPSR() & ~(SR_IRQ | SR_FIQ));
     #else
     asm("cpsie if\n\t");
     #endif

--- a/common/types.h
+++ b/common/types.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 #define BIT(x) (1<<(x))
 

--- a/link.ld
+++ b/link.ld
@@ -18,5 +18,6 @@ SECTIONS
     __end__ = ABSOLUTE(.);
 
     __stack_top = __start__;
+    __stack_abt = 0x8000;
     __code_size__ = __end__ - __start__;
 }

--- a/screeninit/Makefile
+++ b/screeninit/Makefile
@@ -12,10 +12,12 @@ dir_source := source
 dir_build := build
 dir_out := ../$(dir_build)
 
-ASFLAGS := -mcpu=mpcore -mfloat-abi=soft
-CFLAGS  := -DARM11 -Wall -Wextra -MMD -MP -marm -mno-thumb-interwork \
-           $(ASFLAGS) -fno-builtin -std=c11 -Wno-main -O2 -flto -ffast-math \
-           -I$(dir_source) -I../common
+ARCH    := -DARM11 -mcpu=mpcore -mfloat-abi=soft -marm -mno-thumb-interwork
+INCLUDE := -I$(dir_source) -I../common
+
+ASFLAGS := $(ARCH) -x assembler-with-cpp $(INCLUDE)
+CFLAGS  := $(ARCH) -Wall -Wextra -MMD -MP -fno-builtin \
+           -std=c11 -O2 -flto -ffast-math -Wno-main $(INCLUDE)
 LDFLAGS := -nostdlib -nostartfiles
 
 objects = $(patsubst $(dir_source)/%.s, $(dir_build)/%.o, \
@@ -37,8 +39,8 @@ $(dir_out)/$(name).elf: $(objects)
 
 $(dir_build)/%.o: $(dir_source)/%.c
 	@mkdir -p "$(@D)"
-	$(COMPILE.c) $(OUTPUT_OPTION) $<
+	$(CC) -c $(CFLAGS) -o $@ $<
 
 $(dir_build)/%.o: $(dir_source)/%.s
 	@mkdir -p "$(@D)"
-	$(COMPILE.s) $(OUTPUT_OPTION) $<
+	$(CC) -c $(ASFLAGS) -o $@ $<

--- a/screeninit/linker.ld
+++ b/screeninit/linker.ld
@@ -6,13 +6,12 @@ SECTIONS
 {
     . = 0x1FF80000;
 
-    .text   : ALIGN(4) { *(.text.start) *(.text*); . = ALIGN(4); }
+    .text   : ALIGN(4) { *(.text.boot) *(.text*); . = ALIGN(4); }
     .rodata : ALIGN(4) { *(.rodata*); . = ALIGN(4); }
     .data   : ALIGN(4) { *(.data*); . = ALIGN(8); *(.bss* COMMON); . = ALIGN(8); }
     .bss    : ALIGN(4) { __bss_start = .; *(.bss*); __bss_end = .; }
 
     . = ALIGN(4);
 
-    __irq_stack = 0x1FFFF800;
-    __prg_stack = 0x1FFFF400;
+    __stack_top = 0x1FFFF800;
 }

--- a/screeninit/source/boot.s
+++ b/screeninit/source/boot.s
@@ -8,7 +8,7 @@
 .global __boot
 __boot:
     @ Disable interrupts and switch to IRQ
-    cpsid aif, #(SR_SVC_MODE)
+    cpsid if, #(SR_SVC_MODE)
 
     @ Writeback and invalidate caches
     mov r0, #0
@@ -32,8 +32,8 @@ __boot:
     ldr r1, =__bss_end
     mov r2, #0
     .Lclearbss:
-        str r2, [r0], #4
         cmp r0, r1
+        strlt r2, [r0], #4
         blt .Lclearbss
 
     bl main

--- a/screeninit/source/boot.s
+++ b/screeninit/source/boot.s
@@ -3,10 +3,12 @@
 .section .text.boot
 .arm
 
+#include <arm.h>
+
 .global __boot
 __boot:
     @ Disable interrupts and switch to IRQ
-    cpsid aif, #0x12
+    cpsid aif, #(SR_SVC_MODE)
 
     @ Writeback and invalidate caches
     mov r0, #0
@@ -14,11 +16,7 @@ __boot:
     mcr p15, 0, r0, c7, c14, 0
     mcr p15, 0, r0, c7, c10, 4
 
-    ldr sp, =__irq_stack
-
-    @ Switch to SVC
-    cpsid aif, #0x13
-    ldr sp, =__prg_stack
+    ldr sp, =__stack_top
 
     @ Reset values
     ldr r0, =0x00054078

--- a/screeninit/source/gic.c
+++ b/screeninit/source/gic.c
@@ -10,18 +10,17 @@
 #define IRQ_BASE ((vu32*)0x1FFFFFA0)
 
 irq_handler handler_table[MAX_IRQ];
+extern void (*main_irq_handler)(void);
 
-void __attribute__((interrupt("IRQ"))) gic_irq_handler(void)
+irq_handler GIC_AckIRQ(void)
 {
-    u32 xrq, ss;
-    CPU_EnterCritical(&ss);
-    xrq = *GIC_IRQACK;
+    u32 xrq = *GIC_IRQACK;
+    irq_handler ret = NULL;
     if (xrq < MAX_IRQ && handler_table[xrq]) {
-        (handler_table[xrq])(xrq);
+        ret = handler_table[xrq];
+        *GIC_IRQEND = xrq;
     }
-    *GIC_IRQEND = xrq;
-    CPU_LeaveCritical(&ss);
-    return;
+    return ret;
 }
 
 void GIC_Configure(u32 irq_id, irq_handler hndl)
@@ -35,23 +34,30 @@ void GIC_Configure(u32 irq_id, irq_handler hndl)
 
 void GIC_Reset(void)
 {
+    *DIC_CONTROL = 0;
     *GIC_CONTROL = 0;
-    *GIC_PRIOMASK = ~0;
 
-    for (int i = 0; i < (BIT(9)-1); i++) {
-        *GIC_IRQEND |= i;
+    *GIC_PRIOMASK = ~0;
+    for (int i = 0; i < 0x80; i++) {
+        *GIC_IRQEND = i;
     }
 
-    *DIC_CONTROL = 0;
     for (int i = 0; i < (0x20/4); i++) {
         DIC_CLRENABLE[i] = ~0;
         DIC_PRIORITY[i] = 0;
     }
 
-    *DIC_CONTROL = 1;
-    *GIC_CONTROL = 1;
+    while(*GIC_PENDING != SPURIOUS_IRQ) {
+        for (int i=0; i < (0x20/4); i++) {
+            DIC_CLRPENDING[i] = ~0;
+        }
+    }
 
-    IRQ_BASE[1] = (u32)gic_irq_handler;
+    IRQ_BASE[1] = (u32)&main_irq_handler;
     IRQ_BASE[0] = 0xE51FF004;
+
+    *GIC_CONTROL = 1;
+    *DIC_CONTROL = 1;
+
     return;
 }

--- a/screeninit/source/gic.h
+++ b/screeninit/source/gic.h
@@ -6,51 +6,29 @@
 #pragma once
 #include <types.h>
 
-typedef void (*irq_handler)(u32);
+typedef void (*irq_handler)(void);
 
-#define MAX_IRQ  (0x80)
+#define MAX_IRQ      (0x80)
+
+#define SPURIOUS_IRQ (1023)
 
 #define GIC_BASE (0x17E00100)
 #define DIC_BASE (0x17E01000)
 
-/* Setting bit 0 enables the GIC */
-#define GIC_CONTROL   ((vu32*)(GIC_BASE + 0x00))
-/* Bits [7:0] control the min priority accepted */
-#define GIC_PRIOMASK  ((vu32*)(GIC_BASE + 0x04))
-/* When an IRQ occurrs, this register holds the IRQ ID */
-#define GIC_IRQACK    ((vu32*)(GIC_BASE + 0x0C))
-/* Write the IRQ ID here to acknowledge it */
-#define GIC_IRQEND    ((vu32*)(GIC_BASE + 0x10))
+#define GIC_CONTROL    ((vu32*)(GIC_BASE + 0x00))
+#define GIC_PRIOMASK   ((vu32*)(GIC_BASE + 0x04))
+#define GIC_IRQACK     ((vu32*)(GIC_BASE + 0x0C))
+#define GIC_IRQEND     ((vu32*)(GIC_BASE + 0x10))
+#define GIC_PENDING    ((vu32*)(GIC_BASE + 0x18))
 
+#define DIC_CONTROL    ((vu32*)(DIC_BASE + 0x000))
+#define DIC_SETENABLE  ((vu32*)(DIC_BASE + 0x100))
+#define DIC_CLRENABLE  ((vu32*)(DIC_BASE + 0x180))
+#define DIC_SETPENDING ((vu32*)(DIC_BASE + 0x200))
+#define DIC_CLRPENDING ((vu32*)(DIC_BASE + 0x280))
+#define DIC_PRIORITY   ((vu32*)(DIC_BASE + 0x400))
+#define DIC_PROCTGT    ((vu8*) (DIC_BASE + 0x800))
+#define DIC_CFGREG     ((vu32*)(DIC_BASE + 0xC00))
 
-/* Setting bit 0 enables the DIC */
-#define DIC_CONTROL   ((vu32*)(DIC_BASE + 0x000))
-/*
- Write here to enable an IRQ ID
- The register address is DIC_SETENABLE + (N/32)*4 and its
- corresponding bit index is (N%32)
-*/
-#define DIC_SETENABLE ((vu32*)(DIC_BASE + 0x100))
-
-/* same as above but disables the IRQ */
-#define DIC_CLRENABLE ((vu32*)(DIC_BASE + 0x180))
-
-/* sets the IRQ priority */
-#define DIC_PRIORITY  ((vu32*)(DIC_BASE + 0x400))
-
-/* specifies which CPUs are allowed to be forwarded the IRQ */
-#define DIC_PROCTGT   ((vu8*)(DIC_BASE + 0x800))
-
-/*
- each irq has 2 bits assigned
- bit 0 = 0: uses 1-N model
-         1: uses N-N model
-
- bit 1 = 0: level high active
-         1: rising edge sensitive
- */
-#define DIC_CFGREG    ((vu32*)(DIC_BASE + 0xC00))
-
-void gic_irq_handler(void);
 void GIC_Configure(u32 irq_id, irq_handler hndl);
 void GIC_Reset(void);

--- a/screeninit/source/gic.h
+++ b/screeninit/source/gic.h
@@ -30,5 +30,5 @@ typedef void (*irq_handler)(void);
 #define DIC_PROCTGT    ((vu8*) (DIC_BASE + 0x800))
 #define DIC_CFGREG     ((vu32*)(DIC_BASE + 0xC00))
 
-void GIC_Configure(u32 irq_id, irq_handler hndl);
+void GIC_SetIRQ(u32 irq_id, irq_handler hndl);
 void GIC_Reset(void);

--- a/screeninit/source/irq.s
+++ b/screeninit/source/irq.s
@@ -1,0 +1,29 @@
+.section .text
+.arm
+
+#include <arm.h>
+
+.global main_irq_handler
+.type main_irq_handler, %function
+main_irq_handler:
+    sub lr, lr, #4             @ Fix return address
+    srsdb sp!, #(SR_SVC_MODE)  @ Store IRQ mode LR and SPSR on the SVC stack
+    cps #(SR_SVC_MODE)         @ Switch to SVC mode
+    push {r0-r3,r12}           @ Preserve registers
+    and r1, sp, #4
+    sub sp, sp, r1             @ Word-align stack
+    push {r1,lr}
+
+    bl GIC_AckIRQ              @ Acknowledge interrupt, get handler address
+    cmp r0, #0
+    beq .Lskip_irq
+
+    cpsie i
+    blx r0                     @ Branch to interrupt handler with IRQs enabled
+    cpsid i
+
+    .Lskip_irq:
+    pop {r1,lr}
+    add sp, sp, r1             @ Restore stack pointer
+    pop {r0-r3,lr}             @ Restore registers
+    rfeia sp!                  @ Return From Exception

--- a/screeninit/source/irq.s
+++ b/screeninit/source/irq.s
@@ -8,7 +8,7 @@
 main_irq_handler:
     sub lr, lr, #4             @ Fix return address
     srsdb sp!, #(SR_SVC_MODE)  @ Store IRQ mode LR and SPSR on the SVC stack
-    cps #(SR_SVC_MODE)         @ Switch to SVC mode
+    cpsid i, #(SR_SVC_MODE)    @ Switch to SVC mode
     push {r0-r3,r12}           @ Preserve registers
     and r1, sp, #4
     sub sp, sp, r1             @ Word-align stack
@@ -18,9 +18,7 @@ main_irq_handler:
     cmp r0, #0
     beq .Lskip_irq
 
-    cpsie i
-    blx r0                     @ Branch to interrupt handler with IRQs enabled
-    cpsid i
+    blx r0                     @ Branch to interrupt handler
 
     .Lskip_irq:
     pop {r1,lr}

--- a/screeninit/source/main.c
+++ b/screeninit/source/main.c
@@ -2,6 +2,7 @@
 // check there for license info
 // thanks go to AuroraWright
 #include <types.h>
+#include <arm.h>
 #include <cpu.h>
 #include <gic.h>
 #include <pxi.h>
@@ -154,16 +155,16 @@ void main(void)
 
     PXI_Reset();
     GIC_Reset();
+    GIC_SetIRQ(IRQ_PXI_SYNC, pxi_interrupt_handler);
     screen_init();
+
+    PXI_EnableIRQ();
+    CPU_EnableIRQ();
 
     // Clear ARM11 entrypoint
     *arm11Entry = 0;
 
-    GIC_Configure(IRQ_PXI_SYNC, pxi_interrupt_handler);
-    PXI_EnableIRQ();
-    CPU_EnableIRQ();
-
-    //Wait for the entrypoint to be set, then branch to it
+    // Wait for the entrypoint to be set, then branch to it
     while((entry=*arm11Entry) == 0);
 
     CPU_DisableIRQ();

--- a/screeninit/source/main.c
+++ b/screeninit/source/main.c
@@ -133,7 +133,7 @@ void set_brightness(u8 brightness)
     *(vu32 *)0x10202A40 = brightness;
 }
 
-void pxi_interrupt_handler(__attribute__((unused)) u32 xrq_n)
+void pxi_interrupt_handler(void)
 {
     u8 msg = PXI_GetRemote();
     switch(msg) {

--- a/source/common/xrq.c
+++ b/source/common/xrq.c
@@ -1,0 +1,100 @@
+/*
+ Written by Wolfvak, specially sublicensed under the GPLv2
+ Read LICENSE for more details
+*/
+
+#include "common.h"
+#include "fsinit.h"
+#include "fsutil.h"
+#include "ui.h"
+
+#include <arm.h>
+
+/* Code will be dumped from PC-PC_DUMPRAD to PC+PC_DUMPRAD */
+#define PC_DUMPRAD (0x20)
+
+#define XRQ_DUMPDATAFUNC(type, size) \
+int XRQ_DumpData_##type(char *b, u32 s, u32 e) \
+{ \
+    char *c = b; \
+    while(s<e) { \
+        b+=sprintf(b, "%08lX: ",s); \
+        type *dl = (type*)s; \
+        for (u32 i=0; i<(16/((size)/2)); i++) { \
+            b+=sprintf(b, "%0" #size "lX ", (u32)dl[i]); \
+        } \
+        b+=sprintf(b, "\n"); \
+        s+=16; \
+    } \
+    return (int)(b-c); \
+}
+XRQ_DUMPDATAFUNC(u8,  2)
+XRQ_DUMPDATAFUNC(u16, 4)
+XRQ_DUMPDATAFUNC(u32, 8)
+
+
+// Last 3 should never happen
+const char *XRQ_Name[] = {
+    "Reset", "Undefined", "SWI", "Prefetch Abort",
+    "Data Abort", "", "", ""
+};
+
+extern char __stack_top;
+
+void XRQ_DumpRegisters(u32 xrq, u32 *regs)
+{
+    int y;
+    u32 sp, st, pc;
+    char *wstr = (char*)TEMP_BUFFER, *dumpstr = wstr;
+
+    ClearScreen(MAIN_SCREEN, COLOR_BLACK);
+    wstr += sprintf(wstr, "Exception: %s (%d)\n", XRQ_Name[xrq&7], xrq);
+
+    for (int i = 0; i < 8; i++) {
+        int i_ = i*2;
+        wstr += sprintf(wstr,
+        "R%02d: %08lX | R%02d: %08lX\n", i_, regs[i_], i_+1, regs[i_+1]);
+    }
+
+    wstr += sprintf(wstr, "CPSR: %08lX\n", regs[16]);
+
+    DrawStringF(MAIN_SCREEN, 10, 0, COLOR_WHITE, COLOR_BLACK,
+        dumpstr);
+
+    y = GetDrawStringHeight(dumpstr);
+    DrawStringF(MAIN_SCREEN, 10, y, COLOR_WHITE, COLOR_BLACK,
+        "Reinitializing SD subsystem...");
+    y+=FONT_HEIGHT_EXT;
+
+    while(!InitSDCardFS()) {
+        DeinitSDCardFS();
+    }
+
+    DrawStringF(MAIN_SCREEN, 10, y, COLOR_WHITE, COLOR_BLACK,
+        "Done");
+    y+=FONT_HEIGHT_EXT;
+
+    sp = regs[13] & ~0xF;
+    st = (u32)&__stack_top;
+    if (sp >= 0x20000000 && sp <= st) {
+        wstr += sprintf(wstr, "\nStack dump:\n\n");
+        wstr += XRQ_DumpData_u8(wstr, sp, st);
+    }
+
+    pc = regs[15];
+    wstr += sprintf(wstr, "\nCode dump:\n\n");
+    if (regs[16] & SR_THUMB) {
+        wstr += XRQ_DumpData_u16(wstr, pc-PC_DUMPRAD, pc+PC_DUMPRAD);
+    } else {
+        wstr += XRQ_DumpData_u32(wstr, pc-PC_DUMPRAD, pc+PC_DUMPRAD);
+    }
+
+    DrawStringF(MAIN_SCREEN, 10, y, COLOR_WHITE, COLOR_BLACK,
+        "Dumping state to SD...");
+    y+=FONT_HEIGHT_EXT;
+
+    FileSetData(OUTPUT_PATH"/dump.txt", dumpstr, wstr - dumpstr, 0, true);
+    DrawStringF(MAIN_SCREEN, 10, y, COLOR_WHITE, COLOR_BLACK,
+        "Done");
+    return;
+}

--- a/source/common/xrq_handler.s
+++ b/source/common/xrq_handler.s
@@ -1,0 +1,95 @@
+/*
+ Written by Wolfvak, specially sublicensed under the GPLv2
+ Read LICENSE for more details
+*/
+
+.section .text.xrqh
+.arm
+
+#include <arm.h>
+#include <brf.h>
+
+.macro XRQ_FATAL id=0
+    adr sp, XRQ_Registers
+    stmia sp!, {r0-r12}
+    mov r11, #\id
+    b XRQ_MainHandler
+.endm
+
+.global XRQ_Start
+XRQ_Start:
+XRQ_Vectors:
+    b XRQ_Reset
+    b XRQ_Undefined
+    b XRQ_SWI
+    b XRQ_PAbort
+    b XRQ_DAbort
+    b .             @ Reserved exception vector
+    subs pc, lr, #4 @ IRQs are unhandled
+    b .             @ FIQs are unused (except for debug?)
+
+XRQ_Registers:
+    .space (17*4)
+
+XRQ_Reset:
+    msr cpsr_c, #(SR_ABT_MODE | SR_IRQ | SR_FIQ)
+    XRQ_FATAL 0
+
+XRQ_Undefined:
+    XRQ_FATAL 1
+
+XRQ_SWI:
+    XRQ_FATAL 2
+
+XRQ_PAbort:
+    XRQ_FATAL 3
+
+XRQ_DAbort:
+    XRQ_FATAL 4
+
+XRQ_MainHandler:
+    mrs r10, cpsr
+    mrs r9, spsr
+    mov r8, lr
+
+    @ Disable interrupts
+    orr r0, r0, #(SR_IRQ | SR_FIQ)
+    msr cpsr, r0
+
+    @ Disable mpu / caches
+    ldr r4, =BRF_WB_INV_DCACHE
+    ldr r5, =BRF_INVALIDATE_ICACHE
+    ldr r6, =BRF_RESETCP15
+    blx r4
+    blx r5
+    blx r6
+
+    @ Retrieve banked registers
+    and r0, r9, #(SR_PMODE_MASK)
+    cmp r0, #(SR_USR_MODE)
+    orreq r0, r9, #(SR_SYS_MODE)
+    orr r0, #(SR_IRQ | SR_FIQ)
+
+    msr cpsr_c, r0 @ Switch to previous mode
+    mov r0, sp
+    mov r1, lr
+    msr cpsr, r10  @ Return to abort
+
+    stmia sp!, {r0,r1,r8,r9}
+
+    ldr sp, =__stack_abt
+    ldr r2, =XRQ_DumpRegisters
+    adr r1, XRQ_Registers
+    mov r0, r11
+    blx r2
+
+    msr cpsr_c, #(SR_SVC_MODE | SR_IRQ | SR_FIQ)
+    mov r0, #0
+    .LXRQ_WFI:
+        mcr p15, 0, r0, c7, c0, 4
+        b .LXRQ_WFI
+
+.pool
+
+.global XRQ_End
+XRQ_End:

--- a/source/start.s
+++ b/source/start.s
@@ -2,11 +2,13 @@
 .align 4
 .arm
 
+#include <arm.h>
+
 @ make sure not to clobber r0-r2
 .global _start
 _start:
     @ Switch to supervisor mode and disable interrupts
-    msr cpsr_c, #0xD3
+    msr cpsr_c, #(SR_SVC_MODE | SR_IRQ | SR_FIQ)
 
     @ Short delay (not always necessary, just in case)
     mov r3, #0x40000


### PR DESCRIPTION
The ARM9 exception handler only modifies a small section at the bottom of ITCM, so any other global handlers that may be present won't be affected.

The ARM11 IRQ handler was changed to use some new ARMv6k instructions.