### PR TITLE
Fixed variable typo

### DIFF
--- a/resources/gm9/scripts/Backup EmuNAND.gm9
+++ b/resources/gm9/scripts/Backup EmuNAND.gm9
@@ -2,8 +2,8 @@
 # This will create a backup named [DATESTAMP]_[SERIAL]_emunand_???.bin
 # author: d0k3
 
-set ERRORMSG      "EmuNAND backup failed"
-set SUCCESSMSGMSG "EmuNAND backup success"
+set ERRORMSG   "EmuNAND backup failed"
+set SUCCESSMSG "EmuNAND backup success"
 
 ask "Create a EmuNAND backup in $[GM9OUT]?"
 findnot $[GM9OUT]/$[DATESTAMP]_$[SERIAL]_emunand_???.bin OUTPATH

--- a/resources/gm9/scripts/Backup SysNAND.gm9
+++ b/resources/gm9/scripts/Backup SysNAND.gm9
@@ -2,8 +2,8 @@
 # This will create a backup named [DATESTAMP]_[SERIAL]_sysnand_???.bin
 # author: d0k3
 
-set ERRORMSG      "SysNAND backup failed"
-set SUCCESSMSGMSG "SysNAND backup success"
+set ERRORMSG   "SysNAND backup failed"
+set SUCCESSMSG "SysNAND backup success"
 
 ask "Create a SysNAND backup in $[GM9OUT]?"
 findnot $[GM9OUT]/$[DATESTAMP]_$[SERIAL]_sysnand_???.bin OUTPATH


### PR DESCRIPTION
Replaced `ERRORMSGMSG` with `ERRORMSG` and adjusted the padding to match.