### PR TITLE
SALTMODE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ ifeq ($(AL3X10MODE),1)
 	CFLAGS += -DAL3X10MODE
 endif
 
+ifeq ($(SALTMODE),1)
+	CFLAGS += -DSALTMODE
+endif
+
 ifeq ($(SWITCH_SCREENS),1)
 	CFLAGS += -DSWITCH_SCREENS
 endif


### PR DESCRIPTION
This mode changes GM9 bootloader mode to behave more like an actual bootloader.
Changes:
- No splash.
- No 500ms delay before boot for splash.
- Loading process won't stop because you held a key (other than START), making it possible to get into Luma's config menu in the off chance you need to change something).
- Hold START to get to the menu, instead of R+LEFT.

Compile using `make firm SALTMODE=1`