### PR TITLE
Organize and edit battery color scheme

### DIFF
--- a/source/common/ui.h
+++ b/source/common/ui.h
@@ -51,6 +51,11 @@
 #define COLOR_DARKGREY      RGB(0x50, 0x50, 0x50)
 #define COLOR_DARKESTGREY   RGB(0x20, 0x20, 0x20)
 
+#define COLOR_BATTERY_CHARGING	RGB(0x3D, 0xB7, 0xE4)
+#define COLOR_BATTERY_FULL	RGB(0x49, 0x7E, 0x00)
+#define COLOR_BATTERY_MEDIUM	RGB(0xFF, 0x88, 0x49)
+#define COLOR_BATTERY_LOW	RGB(0xB4, 0x00, 0x00)
+
 #define COLOR_TRANSPARENT   RGB(0xFF, 0x00, 0xEF) // otherwise known as 'super fuchsia'
 
 #define COLOR_STD_BG        COLOR_BLACK

--- a/source/godmode.c
+++ b/source/godmode.c
@@ -122,7 +122,7 @@ void GenerateBatteryBitmap(u8* bitmap, u32 width, u32 height, u32 color_bg) {
     CheckBattery(&battery, &is_charging);
     
     u32 color_battery = (is_charging) ? COLOR_BATTERY_CHARGING :
-        (battery > 70) ? COLOR_BATTERY_GREEN : (battery > 30) ? COLOR_BATTERY_MEDIUM : COLOR_BATTERY_LOW;
+        (battery > 70) ? COLOR_BATTERY_FULL : (battery > 30) ? COLOR_BATTERY_MEDIUM : COLOR_BATTERY_LOW;
     u32 nub_size = (height < 12) ? 1 : 2;
     u32 width_inside = width - 4 - nub_size;
     u32 width_battery = (battery >= 100) ? width_inside : ((battery * width_inside) + 50) / 100;

--- a/source/godmode.c
+++ b/source/godmode.c
@@ -121,8 +121,8 @@ void GenerateBatteryBitmap(u8* bitmap, u32 width, u32 height, u32 color_bg) {
     bool is_charging;
     CheckBattery(&battery, &is_charging);
     
-    u32 color_battery = (is_charging) ? COLOR_BLUE :
-        (battery > 70) ? COLOR_GREEN : (battery > 30) ? COLOR_YELLOW : COLOR_RED;
+    u32 color_battery = (is_charging) ? COLOR_BATTERY_CHARGING :
+        (battery > 70) ? COLOR_BATTERY_GREEN : (battery > 30) ? COLOR_BATTERY_MEDIUM : COLOR_BATTERY_LOW;
     u32 nub_size = (height < 12) ? 1 : 2;
     u32 width_inside = width - 4 - nub_size;
     u32 width_battery = (battery >= 100) ? width_inside : ((battery * width_inside) + 50) / 100;


### PR DESCRIPTION
Separates the battery colors into separate values in "ui.h" and edits them to be easier on the eyes (at least in my opinion). Colors are open for improvements.