### PR TITLE
Fix building the tar archive on macOS (and probably BSD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(if $(wildcard $1),-C"$(shell dirname "$(abspath $(1))")" "$(shell basename $(1
 endef
 
 define ADDTARFOLDER
-$(if $(wildcard $1/*),-C"$(abspath $(VRAM_DATA))" $(shell find $(VRAM_DATA) -mindepth 1 -maxdepth 1 -exec basename -a {} + | sed 's,\(.*\),"\1",'))
+$(if $(wildcard $1/*),-C"$(abspath $(1))" $(shell find $(1) -mindepth 1 -maxdepth 1 -exec basename {} + | sed 's,\(.*\),"\1",'))
 endef
 
 # Definitions for initial RAM disk

--- a/Makefile
+++ b/Makefile
@@ -14,29 +14,25 @@ export DBUILTL  :=	$(shell date +'%Y-%m-%d %H:%M:%S')
 export OUTDIR := output
 export RELDIR := release
 
+define ADDTARFILE
+$(if $(wildcard $1),-C"$(shell dirname "$(abspath $(1))")" "$(shell basename $(1))")
+endef
+
+define ADDTARFOLDER
+$(if $(wildcard $1/*),-C"$(abspath $(VRAM_DATA))" $(shell find $(VRAM_DATA) -mindepth 1 -maxdepth 1 -exec basename -a {} + | sed 's,\(.*\),"\1",'))
+endef
+
 # Definitions for initial RAM disk
 VRAM_OUT    := $(OUTDIR)/vram0.tar
 VRAM_DATA   := data
 VRAM_FLAGS  := -b 1
+VRAM_FILES  := $(call ADDTARFILE,$(README)) $(call ADDTARFILE,$(SPLASH)) $(call ADDTARFOLDER,$(VRAM_DATA))
 
 # Choose format depending on the OS, disable exporting macOS resource forks to hidden files in the tar
 ifeq ($(shell uname -s),Darwin)
     VRAM_FLAGS += --format ustar --disable-copyfile
 else
     VRAM_FLAGS += --format v7
-endif
-
-# Check for files and add them
-ifneq ("$(wildcard $(README))","")
-    VRAM_FILES += -C"$(shell echo \"$(abspath $(README))\" | xargs dirname)" "$(shell echo $(README) | xargs basename)"
-endif
-
-ifneq ("$(wildcard $(SPLASH))","")
-    VRAM_FILES += -C"$(shell echo \"$(abspath $(SPLASH))\" | xargs dirname)" "$(shell echo $(SPLASH) | xargs basename)"
-endif
-
-ifneq ("$(wildcard $(VRAM_DATA)/*)","")
-    VRAM_FILES += -C"$(abspath $(VRAM_DATA))" $(shell find $(VRAM_DATA) -mindepth 1 -maxdepth 1 -exec basename -a {} + | sed 's,\(.*\),"\1",')
 endif
 
 # Definitions for ARM binaries

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,12 @@ export RELDIR := release
 # Definitions for initial RAM disk
 VRAM_OUT    := $(OUTDIR)/vram0.tar
 VRAM_DATA   := data
-VRAM_FLAGS  := --format=v7 --blocking-factor=1 --xform='s/^$(VRAM_DATA)\/\|^resources\///'
+VRAM_FLAGS  := --format ustar -b 1
+
+# Disable exporting macOS resource forks to hidden files in the tar
+ifeq ($(shell uname -s),Darwin)
+    VRAM_FLAGS += --disable-copyfile
+endif
 
 # Definitions for ARM binaries
 export INCLUDE := -I"$(shell pwd)/common"
@@ -62,7 +67,9 @@ release: clean
 vram0:
 	@mkdir -p "$(OUTDIR)"
 	@echo "Creating $(VRAM_OUT)"
-	@tar cf $(VRAM_OUT) $(VRAM_FLAGS) $(shell ls -d $(README) $(SPLASH) $(VRAM_DATA)/*)
+	@tar cf $(VRAM_OUT) $(VRAM_FLAGS) -C$(shell echo $(abspath $(README)) | xargs dirname) $(shell echo $(README) | xargs basename) \
+	                                  -C$(shell echo $(abspath $(SPLASH)) | xargs dirname) $(shell echo $(SPLASH) | xargs basename) \
+	                                  -C$(abspath $(VRAM_DATA)) $(shell ls -d $(VRAM_DATA)/* | xargs -n 1 basename)
 
 elf:
 	@set -e; for elf in $(ELF); do \

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ endif
 
 # Check for files and add them
 ifneq ("$(wildcard $(README))","")
-    VRAM_FILES += -C"$(shell echo $(abspath $(README)) | xargs dirname)" "$(shell echo $(README) | xargs basename)"
+    VRAM_FILES += -C"$(shell echo \"$(abspath $(README))\" | xargs dirname)" "$(shell echo $(README) | xargs basename)"
 endif
 
 ifneq ("$(wildcard $(SPLASH))","")
-    VRAM_FILES += -C"$(shell echo $(abspath $(SPLASH)) | xargs dirname)" "$(shell echo $(SPLASH) | xargs basename)"
+    VRAM_FILES += -C"$(shell echo \"$(abspath $(SPLASH))\" | xargs dirname)" "$(shell echo $(SPLASH) | xargs basename)"
 endif
 
 ifneq ("$(wildcard $(VRAM_DATA)/*)","")


### PR DESCRIPTION
Tested with GNU tar (included in Linux distros) and BSD tar (included in macOS/BSD).
"--disable-copyfile" is macOS specific and causes an error on GNU tar so it's only added if macOS is detected