### PR TITLE
load gm9 if no payload is found

### DIFF
--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -1934,6 +1934,9 @@ u32 GodMode(int entrypoint) {
         if (IsBootableFirm(firm_in_mem, FIRM_MAX_SIZE)) BootFirm(firm_in_mem, "sdmc:/bootonce.firm");
         for (u32 i = 0; i < sizeof(bootfirm_paths) / sizeof(char*); i++) {
             BootFirmHandler(bootfirm_paths[i], false, (BOOTFIRM_TEMPS >> i) & 0x1);
+        if (bootloader) { // Megumin is the best girl! ~Eix
+            godmode9 = true; // if no payload is detected in bootloader mode it will load gm9 instead of turning of the 3ds
+        }
         }
     }
     


### PR DESCRIPTION
if your use the bootloader function and you dont have a payload to boot it will normally turn off
but puting that after the BootFirmHandler will load gm9 instead of shuting down
if a payload to boot is found this will not be reached because it stops the function to boot the payload
this is 99.99% safe
i just dont know what happens if a broken payload is loaded because i have no broken payload to test it with
but if a broken payload is used im pretty sure the 3ds will just shutdown