### PR TITLE
Buffer all BPS, IPS, CRC32 reads in chunks of 1 MB or less

### DIFF
--- a/arm9/source/crypto/crc32.h
+++ b/arm9/source/crypto/crc32.h
@@ -5,6 +5,6 @@
 #pragma once
 #include "vff.h"
 
-uint32_t crc32_adjust(uint32_t crc32, uint8_t input);
-uint32_t crc32_calculate(const uint8_t* data, unsigned int length);
-uint32_t crc32_calculate_from_file(FIL inputFile, unsigned int length);
+u32 crc32_adjust(u32 crc32, u8 input);
+u32 crc32_calculate(u32 crc32, const u8* data, u32 length);
+u32 crc32_calculate_from_file(const char* fileName, u32 offset, u32 length);


### PR DESCRIPTION
As the title states, all reads are now buffered in large chunks of STD_BUFFER_SIZE. CRC32 was trivial and IPS was straightforward - the nature of the format limits IPS to fairly small files that are read linearly from beginning to end.

BPS, however, necessitated a complete rewrite. Files can be any size and read from any point in the source or target files as many times as they wish, and they take full advantage of this - BPS patches are essentially a compressed archive containing the target file compressed using both the source file and previous sections of the target file itself as a dictionary, with equal or even superior efficiency in my tests to the bzip2-leveraging bsdiff format.

The previous BPS implementation tried to read patch, source, and target files into memory before falling back to simply reading the requested portions of the file on demand. For files of any reasonable size, this resulted in a **ludicrous** amount of tiny reads and writes, usually overlapping with data that had been previously read. The overhead and inefficiency could result in enough slowdown as to be practically unusable, so a growing amount of cruft was devoted to workarounds avoiding this fallback at all costs. I wasn't too happy with it.

So naturally, I wrote my own memory management system.

Instead of an array of bytes, file data is represented by an array of DataChunk structs, themselves each representing non-overlapping STD_BUFFER_SIZEd pieces of the file. Data reads intelligently switch between chunks midstream with a minimum of overhead, chunks are allocated only when requested, and when more memory is required, only the least recently used chunks are deallocated until the needed memory is available.

It's all been tested across a good number of Old and New 3DS's via an installer script patching a few hundred files each go, and we haven't found any issues. Theoretically it should be able to apply any valid BPS/BPM patch now, all at a very reasonable speed - the script previously took at least 20 minutes to complete but now finishes in less than 5.