### PR TITLE
Improved file loading time

### DIFF
--- a/arm9/source/filesys/fsdir.c
+++ b/arm9/source/filesys/fsdir.c
@@ -6,23 +6,24 @@ void DirEntryCpy(DirEntry* dest, const DirEntry* orig) {
 }
 
 int compDirEntry(const void* e1, const void* e2) {
-    const DirEntry* entry1 = *((const DirEntry**) e1);
-    const DirEntry* entry2 = *((const DirEntry**) e2);
+    const DirEntry* entry1 = (const DirEntry*) e1;
+    const DirEntry* entry2 = (const DirEntry*) e2;
     if (entry1->type == T_DOTDOT) return -1;
     if (entry2->type == T_DOTDOT) return 1;
     if (entry1->type != entry2->type)
         return entry1->type - entry2->type;
-    return strncasecmp(entry1->name, entry2->name, 256);
+    return strncasecmp(entry1->path, entry2->path, 256);
 }
 
 void SortDirStruct(DirStruct* contents) {
-    DirEntry* entry_ptr[MAX_DIR_ENTRIES];
-    for (int i = 0; i < (int)contents->n_entries; i++)
-        entry_ptr[i] = &(contents->entry[i]);
-    qsort(entry_ptr, contents->n_entries, sizeof(DirEntry*), compDirEntry);
-    DirEntry tmp[MAX_DIR_ENTRIES];
-    for (int i = 0; i < (int)contents->n_entries; i++)
-        DirEntryCpy(&tmp[i], entry_ptr[i]);
-    for (int i = 0; i < (int)contents->n_entries; i++)
-        DirEntryCpy(&(contents->entry[i]), &tmp[i]);
+    qsort(contents->entry, contents->n_entries, sizeof(DirEntry), compDirEntry);
+    for (int i = 0; i < (int)contents->n_entries; i++) {
+        DirEntry* entry = &(contents->entry[i]);
+        if (entry->type == T_DOTDOT) {
+            entry->name = entry->path + 8;
+        } else {
+            char* slash = strrchr(entry->path, '/');
+            entry->name = slash ? slash + 1 : entry->path;
+        }
+    }
 }

--- a/arm9/source/filesys/fsdir.c
+++ b/arm9/source/filesys/fsdir.c
@@ -5,26 +5,24 @@ void DirEntryCpy(DirEntry* dest, const DirEntry* orig) {
     dest->name = dest->path + (orig->name - orig->path);
 }
 
+int compDirEntry(const void* e1, const void* e2) {
+    const DirEntry* entry1 = *((const DirEntry**) e1);
+    const DirEntry* entry2 = *((const DirEntry**) e2);
+    if (entry1->type == T_DOTDOT) return -1;
+    if (entry2->type == T_DOTDOT) return 1;
+    if (entry1->type != entry2->type)
+        return entry1->type - entry2->type;
+    return strncasecmp(entry1->name, entry2->name, 256);
+}
+
 void SortDirStruct(DirStruct* contents) {
-    for (u32 s = 0; s < contents->n_entries; s++) {
-        DirEntry* cmp0 = &(contents->entry[s]);
-        DirEntry* min0 = cmp0;
-        if (cmp0->type == T_DOTDOT) continue;
-        for (u32 c = s + 1; c < contents->n_entries; c++) {
-            DirEntry* cmp1 = &(contents->entry[c]);
-            if (min0->type != cmp1->type) {
-                if (min0->type > cmp1->type)
-                    min0 = cmp1;
-                continue;
-            }
-            if (strncasecmp(min0->name, cmp1->name, 256) > 0)
-                min0 = cmp1;
-        }
-        if (min0 != cmp0) {
-            DirEntry swap; // swap entries and fix names
-            DirEntryCpy(&swap, cmp0);
-            DirEntryCpy(cmp0, min0);
-            DirEntryCpy(min0, &swap);
-        }
-    }
+    DirEntry* entry_ptr[MAX_DIR_ENTRIES];
+    for (int i = 0; i < (int)contents->n_entries; i++)
+        entry_ptr[i] = &(contents->entry[i]);
+    qsort(entry_ptr, contents->n_entries, sizeof(DirEntry*), compDirEntry);
+    DirEntry tmp[MAX_DIR_ENTRIES];
+    for (int i = 0; i < (int)contents->n_entries; i++)
+        DirEntryCpy(&tmp[i], entry_ptr[i]);
+    for (int i = 0; i < (int)contents->n_entries; i++)
+        DirEntryCpy(&(contents->entry[i]), &tmp[i]);
 }


### PR DESCRIPTION
The present sort algorithm for file sorting is "selection sort".
However, it's a bit slow.

Since qsort is there, you should use qsort for faster sorting.
We can't sort an array of DirEntry directly as qsort uses memcpy for swapping(we have to use DirEntryCpy to swap them) but we can sort an array of pointer of DirEntry.

It's being much faster to load many files in single directory(5s->0.5s for me).
