### PR TITLE
Redo alphabet to be better

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -53,6 +53,10 @@ ifeq ($(SHOW_FREE),1)
     CFLAGS += -DSHOW_FREE
 endif
 
+ifeq ($(NO_LR),1)
+    CFLAGS += -DNO_LR
+endif
+
 ifdef FIXED_BRIGHTNESS
     CFLAGS += -DFIXED_BRIGHTNESS=$(FIXED_BRIGHTNESS)
 endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -53,10 +53,6 @@ ifeq ($(SHOW_FREE),1)
     CFLAGS += -DSHOW_FREE
 endif
 
-ifeq ($(NO_LR),1)
-    CFLAGS += -DNO_LR
-endif
-
 ifdef FIXED_BRIGHTNESS
     CFLAGS += -DFIXED_BRIGHTNESS=$(FIXED_BRIGHTNESS)
 endif

--- a/arm9/source/common/ui.c
+++ b/arm9/source/common/ui.c
@@ -778,11 +778,7 @@ bool ShowInputPrompt(char* inputstr, u32 max_size, u32 resize, const char* alpha
 }
 
 bool ShowStringPrompt(char* inputstr, u32 max_size, const char *format, ...) {
-    #if defined(NO_LR)
-    const char* alphabet = " aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ(){}[]'`^,~*?!@#$%&9876543210=+-_.";
-    #else
-    const char* alphabet = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz(){}[]'`^,~*?!@#$%&0123456789=+-_.";
-    #endif
+    const char* alphabet = " aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ(){}[]'`^,~*?!@#$%&0123456789=+-_.";
     bool ret = false;
     va_list va;
     

--- a/arm9/source/common/ui.c
+++ b/arm9/source/common/ui.c
@@ -778,7 +778,11 @@ bool ShowInputPrompt(char* inputstr, u32 max_size, u32 resize, const char* alpha
 }
 
 bool ShowStringPrompt(char* inputstr, u32 max_size, const char *format, ...) {
+    #if defined(NO_LR)
     const char* alphabet = " aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ(){}[]'`^,~*?!@#$%&9876543210=+-_.";
+    #else
+    const char* alphabet = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz(){}[]'`^,~*?!@#$%&0123456789=+-_.";
+    #endif
     bool ret = false;
     va_list va;
     

--- a/arm9/source/common/ui.c
+++ b/arm9/source/common/ui.c
@@ -778,7 +778,7 @@ bool ShowInputPrompt(char* inputstr, u32 max_size, u32 resize, const char* alpha
 }
 
 bool ShowStringPrompt(char* inputstr, u32 max_size, const char *format, ...) {
-    const char* alphabet = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz(){}[]'`^,~*?!@#$%&0123456789=+-_.";
+    const char* alphabet = " aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ(){}[]'`^,~*?!@#$%&9876543210=+-_.";
     bool ret = false;
     va_list va;
     


### PR DESCRIPTION
Currently renaming a file has all caps and lower grouped together and most files either use all lowercase or have only afew caps
changing the order makes it alittle easier to quickly rename for people who have bad L and R buttons