### PR TITLE
Update cleanup script to add *miner method files

### DIFF
--- a/resources/gm9/scripts/GM9Megascript.gm9
+++ b/resources/gm9/scripts/GM9Megascript.gm9
@@ -1156,12 +1156,25 @@ rm -o -s 0:/savedata
 rm -o -s 0:/sudoku_v0.app
 rm -o -s 0:/4swords.app
  
+rm -o -s 0:/steelhax
+rm -o -s 0:/movable.sed
+rm -o -s 0:/3ds/steelhax_installer.3dsx
+rm -o -s 0:/484E4441.bin.patched
+rm -o -s 0:/frogcert.bin
+rm -o -s 0:/private/ds/app/4B47554A/001/T00031_1038C2A757B77_000.ppm
+rm -o -s 0:/3ds/Frogtool.3dsx
+rm -o -s 0:/3ds/squirrelboot.3dsx
+ 
+ 
 rm -o -s 0:/luma/payloads/ntrboot_flasher.firm
 rm -o -s 0:/ntrboot
 rm -o -s 0:/ntrboot.firm
  
 rm -o -s 0:/boot9strap
-rm -o -s 0:/cias
+
+for 0:/cias *
+    rm -o -s $[FORPATH]
+next
 rm -o -s 0:/gm9/scripts/setup_ctrnand_luma3ds.gm9
 rm -o -s 0:/gm9/scripts/cleanup_sd_card.gm9
 


### PR DESCRIPTION
Hi there!
This PR adds some files which are used to setup the latest *miner methods.
It also changes the handling of the cias folder, because users are often confused as to what to do with a cia when the cias folder suddenly disappears. So this change causes the contents of cias to be deleted, but not the actual folder itself.