### PR TITLE
Fix crashes when opening extensionless files.

### DIFF
--- a/arm9/source/filesys/filetype.c
+++ b/arm9/source/filesys/filetype.c
@@ -132,7 +132,7 @@ u64 IdentifyFileType(const char* path) {
     } else if ((strncasecmp(ext, "png", 4) == 0) &&
         (fsize > sizeof(png_magic)) && (memcmp(data, png_magic, sizeof(png_magic)) == 0)) {
         return GFX_PNG;
-    } else if (ext && ((strncasecmp(ext, "cdn", 4) == 0) || (strncasecmp(ext, "nus", 4) == 0))) {
+    } else if ((strncasecmp(ext, "cdn", 4) == 0) || (strncasecmp(ext, "nus", 4) == 0)) {
         char path_cetk[256];
         char* ext_cetk = path_cetk + (ext - path);
         strncpy(path_cetk, path, 256);
@@ -150,7 +150,7 @@ u64 IdentifyFileType(const char* path) {
         return BIN_LEGKEY; // legacy key file
     } else if (ValidateText((char*) data, (fsize > 0x200) ? 0x200 : fsize)) {
         u64 type = 0;
-        if ((fsize <= SCRIPT_MAX_SIZE) && ext && (strncasecmp(ext, SCRIPT_EXT, strnlen(SCRIPT_EXT, 16) + 1) == 0))
+        if ((fsize <= SCRIPT_MAX_SIZE) && (strncasecmp(ext, SCRIPT_EXT, strnlen(SCRIPT_EXT, 16) + 1) == 0))
             type |= TXT_SCRIPT; // should be a script (which is also generic text)
         if (fsize < STD_BUFFER_SIZE) type |= TXT_GENERIC;
         return type;

--- a/arm9/source/filesys/filetype.c
+++ b/arm9/source/filesys/filetype.c
@@ -25,6 +25,8 @@ u64 IdentifyFileType(const char* path) {
     size_t fsize = FileGetSize(path);
     char* fname = strrchr(path, '/');
     char* ext = (fname) ? strrchr(++fname, '.') : NULL;
+    if (ext) ext++;
+    else ext = "";
     u32 id = 0;
     
     
@@ -32,7 +34,6 @@ u64 IdentifyFileType(const char* path) {
     if (!fname) return 0;
     if (strncmp(fname, "._", 2) == 0) return 0;
     
-    if (ext) ext++;
     if (FileGetData(path, header, 0x200, 0) < min(0x200, fsize)) return 0;
     if (!fsize) return 0;
     

--- a/arm9/source/filesys/filetype.c
+++ b/arm9/source/filesys/filetype.c
@@ -129,7 +129,7 @@ u64 IdentifyFileType(const char* path) {
         (GetNcchInfoVersion((NcchInfoHeader*) data)) &&
         (strncasecmp(fname, NCCHINFO_NAME, 32) == 0)) {
         return BIN_NCCHNFO; // ncchinfo.bin file
-    } else if (ext && (strncasecmp(ext, "png", 4) == 0) &&
+    } else if ((strncasecmp(ext, "png", 4) == 0) &&
         (fsize > sizeof(png_magic)) && (memcmp(data, png_magic, sizeof(png_magic)) == 0)) {
         return GFX_PNG;
     } else if (ext && ((strncasecmp(ext, "cdn", 4) == 0) || (strncasecmp(ext, "nus", 4) == 0))) {
@@ -155,7 +155,7 @@ u64 IdentifyFileType(const char* path) {
         if (fsize < STD_BUFFER_SIZE) type |= TXT_GENERIC;
         return type;
     } else if ((strncmp(path + 2, "/Nintendo DSiWare/", 18) == 0) &&
-        (sscanf(fname, "%08lx.bin", &id) == 1) && ext && (strncasecmp(ext, "bin", 4) == 0)) {
+        (sscanf(fname, "%08lx.bin", &id) == 1) && (strncasecmp(ext, "bin", 4) == 0)) {
         TadHeader hdr;
         if ((FileGetData(path, &hdr, TAD_HEADER_LEN, TAD_HEADER_OFFSET) == TAD_HEADER_LEN) &&
             (strncmp(hdr.magic, TAD_HEADER_MAGIC, strlen(TAD_HEADER_MAGIC)) == 0))

--- a/arm9/source/filesys/filetype.c
+++ b/arm9/source/filesys/filetype.c
@@ -25,8 +25,6 @@ u64 IdentifyFileType(const char* path) {
     size_t fsize = FileGetSize(path);
     char* fname = strrchr(path, '/');
     char* ext = (fname) ? strrchr(++fname, '.') : NULL;
-    if (ext) ext++;
-    else ext = "";
     u32 id = 0;
     
     
@@ -34,6 +32,11 @@ u64 IdentifyFileType(const char* path) {
     if (!fname) return 0;
     if (strncmp(fname, "._", 2) == 0) return 0;
     
+    if (ext) {
+        ext++;
+    } else {
+        ext = "";
+    }
     if (FileGetData(path, header, 0x200, 0) < min(0x200, fsize)) return 0;
     if (!fsize) return 0;
     

--- a/arm9/source/filesys/filetype.c
+++ b/arm9/source/filesys/filetype.c
@@ -125,7 +125,7 @@ u64 IdentifyFileType(const char* path) {
         (GetNcchInfoVersion((NcchInfoHeader*) data)) &&
         (strncasecmp(fname, NCCHINFO_NAME, 32) == 0)) {
         return BIN_NCCHNFO; // ncchinfo.bin file
-    } else if ((strncasecmp(ext, "png", 4) == 0) &&
+    } else if (ext && (strncasecmp(ext, "png", 4) == 0) &&
         (fsize > sizeof(png_magic)) && (memcmp(data, png_magic, sizeof(png_magic)) == 0)) {
         return GFX_PNG;
     } else if (ext && ((strncasecmp(ext, "cdn", 4) == 0) || (strncasecmp(ext, "nus", 4) == 0))) {
@@ -151,7 +151,7 @@ u64 IdentifyFileType(const char* path) {
         if (fsize < STD_BUFFER_SIZE) type |= TXT_GENERIC;
         return type;
     } else if ((strncmp(path + 2, "/Nintendo DSiWare/", 18) == 0) &&
-        (sscanf(fname, "%08lx.bin", &id) == 1) && (strncasecmp(ext, "bin", 4) == 0)) {
+        (sscanf(fname, "%08lx.bin", &id) == 1) && ext && (strncasecmp(ext, "bin", 4) == 0)) {
         TadHeader hdr;
         if ((FileGetData(path, &hdr, TAD_HEADER_LEN, TAD_HEADER_OFFSET) == TAD_HEADER_LEN) &&
             (strncmp(hdr.magic, TAD_HEADER_MAGIC, strlen(TAD_HEADER_MAGIC)) == 0))


### PR DESCRIPTION
I have noticed that trying to open extensionless files crashes, and that this happened after @Wolfvak's MPU fix. Adding some nullchecks seems to fix the issue.

Here is a crash report from the GM9-TD hourly:
```
Exception: Data Abort (4)
GodMode9 v1.8.0-69-g3cbbd538
2019-07-05 01:21:46
 
R00: 00000000 | R01: 08064646
R02: 00000004 | R03: F19FFFFD
R04: 227ED840 | R05: 00F0A0C8
R06: 08064646 | R07: 00000000
R08: 0806464A | R09: 00000200
R10: 227ED940 | R11: 2000135C
R12: 00000005 | R13: 227ED6B8
R14: 08034EDC | R15: 0804D1E4
CPSR: 200000DF

Stack:
227ED6B0: 40 D8 7E 22 64 18 03 08 40 D8 7E 22 C8 A0 F0 00 
227ED6C0: 65 13 00 20 5C 13 00 20 00 00 00 00 DC 4E 03 08 
227ED6D0: 00 00 00 00 53 4D 44 48 33 44 53 58 2C 00 0A 0E 

Code:
0804D1A0: 12800001 131308FF 12800001 E12FFF1E 
0804D1B0: E3520000 0A000020 E92D41F0 E1A07000 
0804D1C0: E1A06001 E0818002 EA000005 E0540005 
0804D1D0: 1A000014 E3550000 0A000014 E1580006 
0804D1E0: 0A000012 E4D74001 EBFFFB93 E0800004 
0804D1F0: E5D03001 E2033003 E3530001 02844020 
0804D200: E4D65001 EBFFFB8C E0800005 E5D03001 
0804D210: E2033003 E3530001 1AFFFFEB E2850020 
```

