### PR TITLE
fix #532

### DIFF
--- a/arm9/source/virtual/vtickdb.c
+++ b/arm9/source/virtual/vtickdb.c
@@ -138,8 +138,13 @@ u64 InitVTickDbDrive(void) { // prerequisite: ticket.db mounted as image
     }
     
     ScanTickDb(false, true);
-    if (!tick_info->n_entries) DeinitVTickDbDrive();
-    return (tick_info->n_entries) ? SYS_TICKDB : 0;
+    
+    if (!tick_info->n_entries) {
+        DeinitVTickDbDrive();
+        return 0;
+    }
+    
+    return SYS_TICKDB;
 }
 
 u64 CheckVTickDbDrive(void) {


### PR DESCRIPTION
Fixes a NULL pointer dereference when cancelling ticket.db mounting, fixing issue #532 