### PR TITLE
Makefile: call firmtool as a PY3 module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ firm: $(ELF) vram0
 	@echo "[VERSION] $(VERSION)"
 	@echo "[BUILD] $(DBUILTL)"
 	@echo "[FIRM] $(FIRM)"
-	@firmtool build $(FIRM) $(FTFLAGS) -g -A 0x18000000 -D $(ELF) $(VRAM_OUT) -C NDMA XDMA memcpy
+	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -A 0x18000000 -D $(ELF) $(VRAM_OUT) -C NDMA XDMA memcpy
 	@echo "[FIRM] $(FIRMD)"
-	@firmtool build $(FIRMD) $(FTDFLAGS) -g -A 0x18000000 -D $(ELF) $(VRAM_OUT)  -C NDMA XDMA memcpy
+	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -A 0x18000000 -D $(ELF) $(VRAM_OUT)  -C NDMA XDMA memcpy
 
 .FORCE:


### PR DESCRIPTION
Calling firmtool directly may not work as expected on Windows, where
Python is not added to PATH by default. However, the py launcher is
always added to a directory in PATH by default.

The only downside is that firmtool with Python 2 will not automatically
be called. Since Python 3.5 is required for add2tar, however, this
shouldn't be an issue.