### PR TITLE
Add handling for SD GBA VC .sav CMAC. (Fixes issue #494).

### DIFF
--- a/arm9/source/utils/nandcmac.c
+++ b/arm9/source/utils/nandcmac.c
@@ -66,34 +66,31 @@ u32 SetupSlot0x30(char drv) {
     
     return 0;
 }
-
 u32 FindAgbSaveSlotOffset(const char* path, u32 cmac_type) {
-    u8 upper_counter[1];
-    u8 lower_counter[1];
+    u32 upper_counter[1];
+    u32 lower_counter[1];
     u32 magic_check[1];
-    u32 slot_offset = 0;
-    u32 bottom_offset[5] = {0x400, 0x2200, 0x8200, 0x10200, 0x20200};
+    u32 slot_offset[6] = {0, 0x400, 0x2200, 0x8200, 0x10200, 0x20200};
     u32 i;
 
-    if (cmac_type == CMAC_AGBSAVE) return (slot_offset); // Does not apply for 'agbsave.bin'.
+    if (cmac_type == CMAC_AGBSAVE) return slot_offset[0]; // Does not apply for 'agbsave.bin'.
     
-    for (i = 0; i <= 4; i++) { // Look for the `.SAV` magic header at the expected bottom slots.
-        if (fvx_qread(path, magic_check, bottom_offset[i], 0x4, NULL) != FR_OK) return 0;
+    for (i = 1; i <= 5; i++) { // Look for the `.SAV` magic header at the expected bottom slots.
+        if (fvx_qread(path, magic_check, slot_offset[i], 0x4, NULL) != FR_OK) return 0;
         if (*magic_check == 0x5641532E) break; // Magic header '.SAV' found.
     }
 
-    if (i == 5) return 0; // Bottom slot not found.
+    if (i == 6) return 0; // Bottom slot not found.
 	
     // Compare top and bottom slots' counter values to determine which is newer.
-    if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 0;
-    if (fvx_qread(path, lower_counter, bottom_offset[i]+0x034, 0x1, NULL) != FR_OK) return 0;
+    if (fvx_qread(path, upper_counter, 0x34, 0x4, NULL) != FR_OK) return 0;
+    if (fvx_qread(path, lower_counter, slot_offset[i]+0x034, 0x4, NULL) != FR_OK) return 0;
 
-    if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)) slot_offset = bottom_offset[i]; // Scenario #1: First save is initialized. Bottom slot is newer.
-    else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) slot_offset = 0;           // Scenario #2: (ie, 0x100 > 0xFF). Top slot is newer.
-    else if (*upper_counter > *lower_counter) slot_offset = 0;                                // Scenario #3: Top slot is newer.
-    else slot_offset = bottom_offset[i];                                                      // Scenario #4: Bottom slot is newer -or- both are the same. 
+    if (*upper_counter == 0xFFFFFFFF);                // Scenario #1: First save is initialized. Bottom slot is newer.
+    else if (*upper_counter > *lower_counter) i = 0;  // Scenario #2: Top slot is newer.
+    // else;                                          // Scenario #3: Bottom slot is newer -or- both are the same. 
 
-    return (slot_offset);
+    return slot_offset[i];
 }
 
 u32 CheckAgbSaveHeader(const char* path) {

--- a/arm9/source/utils/nandcmac.c
+++ b/arm9/source/utils/nandcmac.c
@@ -11,24 +11,19 @@
 // https://3dbrew.org/wiki/Savegames#AES_CMAC_header
 // https://3dbrew.org/wiki/Nand/private/movable.sed
 // https://3dbrew.org/wiki/3DS_Virtual_Console#NAND_Savegame
-#define CMAC_EXTDATA_SD           1
-#define CMAC_EXTDATA_SYS          2
-#define CMAC_SAVEDATA_SYS         3
-#define CMAC_SAVE_GAMECARD        4
-#define CMAC_SAVEGAME             5 // this is not calculated into a CMAC
-#define CMAC_SAVEDATA_SD          6
-#define CMAC_TITLEDB_SYS          7
-#define CMAC_TITLEDB_SD           8
-#define CMAC_MOVABLE              9
-#define CMAC_AGBSAVE             10
-#define CMAC_AGBSAVE_SD          11
-#define CMAC_CMD_SD              12
-#define CMAC_CMD_TWLN            13 // unsupported
-#define CMAC_AGBSAVE_EEPROM_512  14
-#define CMAC_AGBSAVE_EEPROM_64K  15
-#define CMAC_AGBSAVE_SRAM_256K   16
-#define CMAC_AGBSAVE_FLASH_512K  17
-#define CMAC_AGBSAVE_FLASH_1M    18
+#define CMAC_EXTDATA_SD     1
+#define CMAC_EXTDATA_SYS    2
+#define CMAC_SAVEDATA_SYS   3
+#define CMAC_SAVE_GAMECARD  4
+#define CMAC_SAVEGAME       5 // this is not calculated into a CMAC
+#define CMAC_SAVEDATA_SD    6
+#define CMAC_TITLEDB_SYS    7
+#define CMAC_TITLEDB_SD     8
+#define CMAC_MOVABLE        9
+#define CMAC_AGBSAVE       10
+#define CMAC_AGBSAVE_SD    11
+#define CMAC_CMD_SD        12
+#define CMAC_CMD_TWLN      13 // unsupported
 
 // see: https://www.3dbrew.org/wiki/Savegames#AES_CMAC_header
 #define CMAC_SAVETYPE NULL, "CTR-EXT0", "CTR-EXT0", "CTR-SYS0", "CTR-NOR0", "CTR-SAV0", "CTR-SIGN", "CTR-9DB0", "CTR-9DB0", NULL, NULL, NULL
@@ -72,103 +67,70 @@ u32 SetupSlot0x30(char drv) {
     return 0;
 }
 
-u32 CheckAgbSaveHeaderEeprom512(const char* path) {
-    AgbSaveHeader agbsave;
+u32 FindAgbSaveSlotOffset(const char* path, u32 cmac_type) {
     u8 upper_counter[0x1];
     u8 lower_counter[0x1];
-    UINT br;
-    
-	if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 1;
-	if (fvx_qread(path, lower_counter, 0x434, 0x1, NULL) != FR_OK) return 1;
+    u32 magic_check[0x4];
+    u32 slot_offset = 0;
 	
-	if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)); // First save initialized. Bottom slot is newer.
-	else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) return 1; // Top slot is newer.
-	else if (*upper_counter > *lower_counter) return 1; // Compare top and bottom slots.
+    if (cmac_type == CMAC_AGBSAVE) return (slot_offset); // Does not apply for 'agbsave.bin'.
 	
-    if ((fvx_qread(path, &agbsave, 0x400, 0x200, &br) != FR_OK) || (br != 0x200)) return 1;
-	
-	return ValidateAgbSaveHeader(&agbsave);
-}
+    // Look for the `.SAV` magic header at expected bottom offsets.
+    if (fvx_qread(path, magic_check, 0x400, 0x4, NULL) != FR_OK) return 1;
+    if (*magic_check == 0x5641532E) slot_offset = 0x400;
 
-u32 CheckAgbSaveHeaderEeprom64k(const char* path) {
-    AgbSaveHeader agbsave;
-    u8 upper_counter[0x1];
-    u8 lower_counter[0x1];
-    UINT br;
-    
-	if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 1;
-	if (fvx_qread(path, lower_counter, 0x2234, 0x1, NULL) != FR_OK) return 1;
-	
-	if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)); // First save initialized. Bottom slot is newer.
-	else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) return 1; // Top slot is newer.
-	else if (*upper_counter > *lower_counter) return 1; // Compare top and bottom slots.
-	
-    if ((fvx_qread(path, &agbsave, 0x2200, 0x200, &br) != FR_OK) || (br != 0x200)) return 1;
-	
-	return ValidateAgbSaveHeader(&agbsave);
-}
+    if (fvx_qread(path, magic_check, 0x2200, 0x4, NULL) != FR_OK) return 1;
+    if (*magic_check == 0x5641532E) slot_offset = 0x2200;
 
-u32 CheckAgbSaveHeaderSram256k(const char* path) {
-    AgbSaveHeader agbsave;
-    u8 upper_counter[0x1];
-    u8 lower_counter[0x1];
-    UINT br;
-    
-	if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 1;
-	if (fvx_qread(path, lower_counter, 0x8234, 0x1, NULL) != FR_OK) return 1;
-	
-	if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)); // First save initialized. Bottom slot is newer.
-	else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) return 1; // Top slot is newer.
-	else if (*upper_counter > *lower_counter) return 1; // Compare top and bottom slots.
-	
-    if ((fvx_qread(path, &agbsave, 0x8200, 0x200, &br) != FR_OK) || (br != 0x200)) return 1;
-	
-	return ValidateAgbSaveHeader(&agbsave);
-}
+    if (fvx_qread(path, magic_check, 0x8200, 0x4, NULL) != FR_OK) return 1;
+    if (*magic_check == 0x5641532E) slot_offset = 0x8200;
 
-u32 CheckAgbSaveHeaderFlash512k(const char* path) {
-    AgbSaveHeader agbsave;
-    u8 upper_counter[0x1];
-    u8 lower_counter[0x1];
-    UINT br;
-    
-	if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 1;
-	if (fvx_qread(path, lower_counter, 0x10234, 0x1, NULL) != FR_OK) return 1;
-	
-	if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)); // First save initialized. Bottom slot is newer.
-	else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) return 1; // Top slot is newer.
-	else if (*upper_counter > *lower_counter) return 1; // Compare top and bottom slots.
-	
-    if ((fvx_qread(path, &agbsave, 0x10200, 0x200, &br) != FR_OK) || (br != 0x200)) return 1;
-	
-	return ValidateAgbSaveHeader(&agbsave);
-}
+    if (fvx_qread(path, magic_check, 0x10200, 0x4, NULL) != FR_OK) return 1;
+    if (*magic_check == 0x5641532E) slot_offset = 0x10200;
 
-u32 CheckAgbSaveHeaderFlash1M(const char* path) {
-    AgbSaveHeader agbsave;
-    u8 upper_counter[0x1];
-    u8 lower_counter[0x1];
-    UINT br;
+    if (fvx_qread(path, magic_check, 0x20200, 0x4, NULL) != FR_OK) return 1;
+    if (*magic_check == 0x5641532E) slot_offset = 0x20200;
+	
+    // Compare top and bottom slots' counter values to determine which is newer.
+    if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 1;
+    if (fvx_qread(path, lower_counter, slot_offset+0x034, 0x1, NULL) != FR_OK) return 1;
 
-	if (fvx_qread(path, upper_counter, 0x34, 0x1, NULL) != FR_OK) return 1;
-	if (fvx_qread(path, lower_counter, 0x20234, 0x1, NULL) != FR_OK) return 1;
-    
-	if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)); // First save initialized. Bottom slot is newer.
-	else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) return 1; // Top slot is newer.
-	else if (*upper_counter > *lower_counter) return 1; // Compare top and bottom slots.
-	
-    if ((fvx_qread(path, &agbsave, 0x20200, 0x200, &br) != FR_OK) || (br != 0x200)) return 1;
-	
-	return ValidateAgbSaveHeader(&agbsave);
+    if ((*upper_counter == 0xFF) && (*lower_counter == 0x00)); // Scenario #1: First save is initialized. Bottom slot is newer.
+    else if ((*upper_counter == 0x00) && (*lower_counter == 0xFF)) slot_offset = 0; // Scenario #2: (ie, 0x100 > 0xFF). Top slot is newer.
+    else if (*upper_counter > *lower_counter) slot_offset = 0; // Scenario #3: Top slot is newer.
+
+    return (slot_offset);
 }
 
 u32 CheckAgbSaveHeader(const char* path) {
     AgbSaveHeader agbsave;
+    u32 magic_check[0x4];
+    u32 slot_offset = 0;
     UINT br;
-    
-    if ((fvx_qread(path, &agbsave, 0, 0x200, &br) != FR_OK) || (br != 0x200))
-        return 1;
-    
+	
+    // Look for the '.SAV' magic header at the top slot offset.
+    if (fvx_qread(path, magic_check, 0, 0x4, NULL) != FR_OK) return 1;
+
+    // Look for the `.SAV` magic header at expected bottom slot offsets if top is not found.
+    if (*magic_check != 0x5641532E) {
+        if (fvx_qread(path, magic_check, 0x400, 0x4, NULL) != FR_OK) return 1;
+        if (*magic_check == 0x5641532E) slot_offset = 0x400;
+
+        if (fvx_qread(path, magic_check, 0x2200, 0x4, NULL) != FR_OK) return 1;
+        if (*magic_check == 0x5641532E) slot_offset = 0x2200;
+
+        if (fvx_qread(path, magic_check, 0x8200, 0x4, NULL) != FR_OK) return 1;
+        if (*magic_check == 0x5641532E) slot_offset = 0x8200;
+
+        if (fvx_qread(path, magic_check, 0x10200, 0x4, NULL) != FR_OK) return 1;
+        if (*magic_check == 0x5641532E) slot_offset = 0x10200;
+
+        if (fvx_qread(path, magic_check, 0x20200, 0x4, NULL) != FR_OK) return 1;
+        if (*magic_check == 0x5641532E) slot_offset = 0x20200;
+    }
+	
+    if ((fvx_qread(path, &agbsave, slot_offset, 0x200, &br) != FR_OK) || (br != 0x200)) return 1;
+	
     return ValidateAgbSaveHeader(&agbsave);
 }
 
@@ -194,12 +156,7 @@ u32 ReadWriteFileCmac(const char* path, u8* cmac, bool do_write) {
     
     if (!cmac_type) return 1;
     else if (cmac_type == CMAC_MOVABLE) offset = 0x130;
-    else if ((cmac_type == CMAC_AGBSAVE) || (cmac_type == CMAC_AGBSAVE_SD)) offset = 0x010;
-    else if (cmac_type == CMAC_AGBSAVE_EEPROM_512) offset = 0x410;
-    else if (cmac_type == CMAC_AGBSAVE_EEPROM_64K) offset = 0x2210;
-    else if (cmac_type == CMAC_AGBSAVE_SRAM_256K) offset = 0x8210;
-    else if (cmac_type == CMAC_AGBSAVE_FLASH_512K) offset = 0x10210;
-    else if (cmac_type == CMAC_AGBSAVE_FLASH_1M) offset = 0x20210;
+    else if ((cmac_type == CMAC_AGBSAVE) || (cmac_type == CMAC_AGBSAVE_SD)) offset = FindAgbSaveSlotOffset(path, cmac_type) + 0x010;
     else if ((cmac_type == CMAC_CMD_SD) || (cmac_type == CMAC_CMD_TWLN)) return 1; // can't do that here
     else offset = 0x000;
     
@@ -231,13 +188,7 @@ u32 CalculateFileCmac(const char* path, u8* cmac) {
         } else if ((sscanf(path, "%c:/title/%08lx/%08lx/data/%08lx.sav", &drv, &tid_high, &tid_low, &sid) == 4) &&
             ext && (strncasecmp(ext, "sav", 4) == 0)) {
             if (CheckCmacHeader(path) == 0) cmac_type = CMAC_SAVEDATA_SD; // Check for 3DS save data first.
-            else if (CheckAgbSaveHeaderEeprom512(path) == 0) cmac_type = CMAC_AGBSAVE_EEPROM_512; // GBA VC from smallest to largest save sizes.
-            else if (CheckAgbSaveHeaderEeprom64k(path) == 0) cmac_type = CMAC_AGBSAVE_EEPROM_64K;
-            else if (CheckAgbSaveHeaderSram256k(path) == 0) cmac_type = CMAC_AGBSAVE_SRAM_256K;
-            else if (CheckAgbSaveHeaderFlash512k(path) == 0) cmac_type = CMAC_AGBSAVE_FLASH_512K;
-            else if (CheckAgbSaveHeaderFlash1M(path) == 0) cmac_type = CMAC_AGBSAVE_FLASH_1M;
             else if (CheckAgbSaveHeader(path) == 0) cmac_type = CMAC_AGBSAVE_SD;
-            else cmac_type = 0;
         } else if ((sscanf(path, "%c:/title/%08lx/%08lx/content/cmd/%08lx.cmd", &drv, &tid_high, &tid_low, &sid) == 4) &&
             ext && (strncasecmp(ext, "cmd", 4) == 0)) {
             cmac_type = CMAC_CMD_SD; // this needs special handling, it's in here just for detection
@@ -293,83 +244,13 @@ u32 CalculateFileCmac(const char* path, u8* cmac) {
         UINT br;
         
         if (!agbsave) return 1;
-        if ((fvx_qread(path, agbsave, 0, AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
+        if ((fvx_qread(path, agbsave, FindAgbSaveSlotOffset(path, cmac_type), AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
             (ValidateAgbSaveHeader(agbsave) != 0) || (0x200 + agbsave->save_size > br)) {
             free(agbsave);
             return 1;
         }
         
         u32 ret = FixAgbSaveCmac(agbsave, cmac, (cmac_type == CMAC_AGBSAVE) ? NULL : path);
-        free(agbsave);
-        return ret;
-    } else if (cmac_type == CMAC_AGBSAVE_EEPROM_512) {
-        AgbSaveHeader* agbsave = (AgbSaveHeader*) malloc(AGBSAVE_MAX_SIZE);
-        UINT br;
-        
-        if (!agbsave) return 1;
-        if ((fvx_qread(path, agbsave, 0x400, AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
-            (ValidateAgbSaveHeader(agbsave) != 0) || (0x200 + agbsave->save_size > br)) {
-            free(agbsave);
-            return 1;
-        }
-        
-        u32 ret = FixAgbSaveCmac(agbsave, cmac, path);
-        free(agbsave);
-        return ret;
-    } else if (cmac_type == CMAC_AGBSAVE_EEPROM_64K) {
-        AgbSaveHeader* agbsave = (AgbSaveHeader*) malloc(AGBSAVE_MAX_SIZE);
-        UINT br;
-        
-        if (!agbsave) return 1;
-        if ((fvx_qread(path, agbsave, 0x2200, AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
-            (ValidateAgbSaveHeader(agbsave) != 0) || (0x200 + agbsave->save_size > br)) {
-            free(agbsave);
-            return 1;
-        }
-        
-        u32 ret = FixAgbSaveCmac(agbsave, cmac, path);
-        free(agbsave);
-        return ret;
-    } else if (cmac_type == CMAC_AGBSAVE_SRAM_256K) {
-        AgbSaveHeader* agbsave = (AgbSaveHeader*) malloc(AGBSAVE_MAX_SIZE);
-        UINT br;
-        
-        if (!agbsave) return 1;
-        if ((fvx_qread(path, agbsave, 0x8200, AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
-            (ValidateAgbSaveHeader(agbsave) != 0) || (0x200 + agbsave->save_size > br)) {
-            free(agbsave);
-            return 1;
-        }
-        
-        u32 ret = FixAgbSaveCmac(agbsave, cmac, path);
-        free(agbsave);
-        return ret;
-    } else if (cmac_type == CMAC_AGBSAVE_FLASH_512K) {
-        AgbSaveHeader* agbsave = (AgbSaveHeader*) malloc(AGBSAVE_MAX_SIZE);
-        UINT br;
-        
-        if (!agbsave) return 1;
-        if ((fvx_qread(path, agbsave, 0x10200, AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
-            (ValidateAgbSaveHeader(agbsave) != 0) || (0x200 + agbsave->save_size > br)) {
-            free(agbsave);
-            return 1;
-        }
-        
-        u32 ret = FixAgbSaveCmac(agbsave, cmac, path);
-        free(agbsave);
-        return ret;
-    } else if (cmac_type == CMAC_AGBSAVE_FLASH_1M) {
-        AgbSaveHeader* agbsave = (AgbSaveHeader*) malloc(AGBSAVE_MAX_SIZE);
-        UINT br;
-        
-        if (!agbsave) return 1;
-        if ((fvx_qread(path, agbsave, 0x20200, AGBSAVE_MAX_SIZE, &br) != FR_OK) || (br < 0x200) ||
-            (ValidateAgbSaveHeader(agbsave) != 0) || (0x200 + agbsave->save_size > br)) {
-            free(agbsave);
-            return 1;
-        }
-        
-        u32 ret = FixAgbSaveCmac(agbsave, cmac, path);
         free(agbsave);
         return ret;
     } else if (cmac_type == CMAC_MOVABLE) { // movable.sed
@@ -431,7 +312,8 @@ u32 CheckFileCmac(const char* path) {
         u8 ccmac[16];
         return ((ReadFileCmac(path, fcmac) == 0) && (CalculateFileCmac(path, ccmac) == 0) &&
             (memcmp(fcmac, ccmac, 16) == 0)) ? 0 : 1;
-    } else return 1;   
+    } else return 1;
+    
 }
 
 u32 FixFileCmac(const char* path) {
@@ -514,6 +396,7 @@ u32 CheckFixCmdCmac(const char* path, bool fix) {
         free(cmd_data);
         return 1;
     }
+
 
     // now, check the CMAC@0x10
     use_aeskey(keyslot);


### PR DESCRIPTION
When identifying a selected `00000001.sav`, cmac type testing is first attempted for 3DS saves with the **DISA** format. If a 3DS save data is not detected, the search continues at expected offsets for gba vc bottom slots in increasingly larger save sizes. For the GBA VC saves, this only calculates and corrects whichever of the two slots is newer or has the higher counter. There are five additional **CMAC_AGBSAVE_** types to differentiate the different gba save sizes. If a bottom slot was found but determined to be older based on comparing the counter values, the search defaults to **CMAC_AGBSAVE_SD**.

For the save counters, there are two scenarios where the value `00` is considered bigger than `FF` depending which slot has what. If clarification is required, I will post a diagram at [issue #494](https://github.com/d0k3/GodMode9/issues/494) explaining what is meant by `00` bigger than `FF`.

Please make corrections and improvements to the coding as you see fit in your peer review. I am not well versed or efficient in the C/C++ programming language.