### PR TITLE
Change timeout on CardSPIWaitWriteEnd to improve responsiveness

### DIFF
--- a/arm9/source/gamecart/card_spi.h
+++ b/arm9/source/gamecart/card_spi.h
@@ -67,7 +67,7 @@ const CardSPITypeData * const FLASH_512KB_CTR; // Also common, including Detecti
 const CardSPITypeData * const FLASH_1MB_CTR; // For example Pokemon Ultra Sun
 
 int CardSPIWriteRead(CardSPIType type, const void* cmd, u32 cmdSize, void* answer, u32 answerSize, const void* data, u32 dataSize);
-int CardSPIWaitWriteEnd(CardSPIType type);
+int CardSPIWaitWriteEnd(CardSPIType type, u32 timeout);
 int CardSPIEnableWriting(CardSPIType type);
 int CardSPIReadJEDECIDAndStatusReg(CardSPIType type, u32* id, u8* statusReg);
 int CardSPIGetCardSPIType(CardSPIType* type, bool infrared);


### PR DESCRIPTION
Allows long waits for erase on things like Art Academy, but fails faster
elsewhere. In particular initialization fails almost instantly.