### PR TITLE
add a9lh stage2 payload removal to the uninstall hax script

### DIFF
--- a/resources/gm9/scripts/GM9Megascript.gm9
+++ b/resources/gm9/scripts/GM9Megascript.gm9
@@ -443,7 +443,7 @@ if	allow -a S:
 		fget S:/nand.bin@57FFE00:1 PRE_STAGE2
 		fill S:/nand.bin@B7FFE00:89C00 $[PRE_STAGE2]
 	end
-	echo "CFW un-installed successfully"
+	echo "CFW uninstalled successfully"
 else
 	echo "Permissions denied. Aborting."
 end
@@ -462,8 +462,8 @@ set NATIVE_FIRM $[GM9OUT]/NATIVE_FIRM.firm
 cp -w G:/exefs/.firm $[NATIVE_FIRM]
 imgumount
 
-if	allow S:/nand.bin
-	allow 1:
+if	allow -a S:
+	allow -a 1:
 	rm -o -s 1:/boot.firm
 	rm -o -s 1:/rw/luma
 	cp -n $[NATIVE_FIRM] S:/firm0.bin

--- a/resources/gm9/scripts/GM9Megascript.gm9
+++ b/resources/gm9/scripts/GM9Megascript.gm9
@@ -438,6 +438,11 @@ if	allow -a S:
 	rm -o -s 1:/rw/luma
 	cp -n $[NATIVE_FIRM] S:/firm0.bin
 	cp -n $[NATIVE_FIRM] S:/firm1.bin
+	shaget S:/nand.bin@57FFE00:200 PRE_STAGE2_HASH
+	if not sha S:/nand.bin@B800000:200 $[PRE_STAGE2_HASH]
+		fget S:/nand.bin@57FFE00:1 PRE_STAGE2
+		fill S:/nand.bin@B7FFE00:89C00 $[PRE_STAGE2]
+	end
 	echo "CFW un-installed successfully"
 else
 	echo "Permissions denied. Aborting."
@@ -463,6 +468,11 @@ if	allow S:/nand.bin
 	rm -o -s 1:/rw/luma
 	cp -n $[NATIVE_FIRM] S:/firm0.bin
 	cp -n $[NATIVE_FIRM] S:/firm1.bin
+	shaget S:/nand.bin@57FFE00:200 PRE_STAGE2_HASH
+	if not sha S:/nand.bin@B800000:200 $[PRE_STAGE2_HASH]
+		fget S:/nand.bin@57FFE00:1 PRE_STAGE2
+		fill S:/nand.bin@B7FFE00:89C00 $[PRE_STAGE2]
+	end
 	echo "CFW uninstalled successfully"
 else
 	echo "Permissions denied. Aborting."


### PR DESCRIPTION
This code will check if the hash of NAND sector 0x5BFFF matches the hash of NAND sector 0x5C000, and fill 0x89C00 bytes starting at sector 0x5BFFF with the byte at the beginning of sector 0x5BFFF if the hash does not match. Under unmodified circumstances, both of these sectors will be filled with 0xFF or 0x00. Sector 0x5C000 is where the stage2 payload gets written when installing a9lh, with a maximum size of 0x89A00 bytes. If this payload is not removed when uninstalling CFW, then attempting to reinstall it later using any method which involves b9stool will cause a false positive a9lh warning to be given.

I also changed a couple minor things to be consistent between the uninstall code for new models and old models.