### PR TITLE
add another pxi barrier for firmlaunch

### DIFF
--- a/arm11/source/main.c
+++ b/arm11/source/main.c
@@ -196,12 +196,15 @@ void __attribute__((noreturn)) MainLoop(void)
 	gicEnableInterrupt(VBLANK_INTERRUPT);
 
 	// ARM9 won't try anything funny until this point
-	PXI_Barrier(ARM11_READY_BARRIER);
+	PXI_Barrier(PXI_BOOT_BARRIER);
 
 	// Process IRQs until the ARM9 tells us it's time to boot something else
 	do {
 		ARM_WFI();
 	} while(!legacy_boot);
+
+	// Wait for the ARM9 to do its firmlaunch setup
+	PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
 
 	SYS_CoreZeroShutdown();
 	SYS_CoreShutdown();

--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -110,6 +110,7 @@ u32 BootFirmHandler(const char* bootpath, bool verbose, bool delete) {
         DeinitSDCardFS();
         PXI_DoCMD(PXI_SET_VMODE, (u32[]){1}, 1);
         PXI_DoCMD(PXI_LEGACY_MODE, NULL, 0);
+        PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
         BootFirm((FirmHeader*) firm, fixpath);
         while(1);
     }
@@ -2272,7 +2273,10 @@ u32 GodMode(int entrypoint) {
     // bootloader handler
     if (bootloader) {
         const char* bootfirm_paths[] = { BOOTFIRM_PATHS };
-        if (IsBootableFirm(firm_in_mem, FIRM_MAX_SIZE)) BootFirm(firm_in_mem, "sdmc:/bootonce.firm");
+        if (IsBootableFirm(firm_in_mem, FIRM_MAX_SIZE)) {
+            PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
+            BootFirm(firm_in_mem, "sdmc:/bootonce.firm");
+        }
         for (u32 i = 0; i < sizeof(bootfirm_paths) / sizeof(char*); i++) {
             BootFirmHandler(bootfirm_paths[i], false, (BOOTFIRM_TEMPS >> i) & 0x1);
         }

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -18,7 +18,7 @@ void main(int argc, char** argv, int entrypoint)
 
     // Don't even try to send any messages until the
     // ARM11 says it's ready
-    PXI_Barrier(ARM11_READY_BARRIER);
+    PXI_Barrier(PXI_BOOT_BARRIER);
 
     // A pointer to the shared memory region is
     // stored in the thread ID register in the ARM9

--- a/arm9/source/utils/scripting.c
+++ b/arm9/source/utils/scripting.c
@@ -1428,6 +1428,7 @@ bool run_cmd(cmd_id id, u32 flags, char** argv, char* err_str) {
                 DeinitSDCardFS();
                 PXI_DoCMD(PXI_SET_VMODE, (u32[]){1}, 1);
                 PXI_DoCMD(PXI_LEGACY_MODE, NULL, 0);
+                PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
                 BootFirm((FirmHeader*)(void*)firm, fixpath);
                 while(1);
             } else if (err_str) snprintf(err_str, _ERR_STR_LEN, "not a bootable firm");

--- a/common/pxi.h
+++ b/common/pxi.h
@@ -48,7 +48,8 @@ enum {
  * those used by any other software
  */
 enum {
-	ARM11_READY_BARRIER = 19,
+	PXI_BOOT_BARRIER = 19,
+	PXI_FIRMLAUNCH_BARRIER = 153,
 };
 
 #define PXI_FIFO_LEN	(16)


### PR DESCRIPTION
fixes a race condition when booting gm9 from itself (especially noticeable on new3DS consoles)

submitted as a PR for testing/debugging/commenting/reviewing/etc, will be merged to master when confirmed fully working