### PR TITLE
Finalize game installer functionality

### DIFF
--- a/arm9/source/common/swkbd.c
+++ b/arm9/source/common/swkbd.c
@@ -136,7 +136,7 @@ static void DrawTextBox(const TouchBox* txtbox, const char* inputstr, const u32 
         (*scroll) ? '<' : '|',
         (inputstr_size > input_shown) ? input_shown : inputstr_size,
         (inputstr_size > input_shown) ? input_shown : inputstr_size,
-        inputstr + *scroll,
+        (*scroll > inputstr_size) ? "" : inputstr + *scroll,
         (inputstr_size > input_shown) ? 0 : input_shown - inputstr_size,
         (inputstr_size > input_shown) ? 0 : input_shown - inputstr_size,
         "",

--- a/arm9/source/game/seedsave.c
+++ b/arm9/source/game/seedsave.c
@@ -1,0 +1,240 @@
+#include "seedsave.h"
+#include "support.h"
+#include "nandcmac.h"
+#include "sha.h"
+#include "ff.h"
+
+#define TITLETAG_MAX_ENTRIES  2000 // same as SEEDSAVE_MAX_ENTRIES
+#define TITLETAG_AREA_OFFSET  0x10000 // thanks @luigoalma
+
+// this structure is 0x80 bytes, thanks @luigoalma
+typedef struct {
+  char magic[4]; // "PREP" for prepurchase install. NIM excepts "PREP" to do seed downloads on the background.
+  // playable date parameters
+  // 2000-01-01 is a safe bet for a stub entry
+  s32 year;
+  u8 month;
+  u8 day;
+  u16 country_code; // enum list of values, this will affect seed downloading, just requires at least one valid enum value. 1 == Japan, it's enough.
+  // everything after this point can be 0 padded
+  u32 seed_status; // 0 == not tried, 1 == last attempt failed, 2 == seed downloaded successfully
+  s32 seed_result; // result related to last download attempt
+  s32 seed_support_error_code; // support code derived from the result code 
+  // after this point, all is unused or padding. NIM wont use or access this at all.
+  // It's memset to 0 by NIM
+  u8 unknown[0x68];
+} PACKED_STRUCT TitleTagEntry;
+
+typedef struct {
+	u32 unknown0;
+	u32 n_entries;
+	u8  unknown1[0x1000 - 0x8];
+	u64 titleId[TITLETAG_MAX_ENTRIES];
+	TitleTagEntry tag[TITLETAG_MAX_ENTRIES];
+} PACKED_STRUCT TitleTag;
+
+u32 GetSeedPath(char* path, const char* drv) {
+    u8 movable_keyy[16] = { 0 };
+    u32 sha256sum[8];
+    UINT btr = 0;
+    FIL file;
+
+    // grab the key Y from movable.sed
+    // wrong result if movable.sed does not have it
+    snprintf(path, 128, "%2.2s/private/movable.sed", drv);
+    if (f_open(&file, path, FA_READ | FA_OPEN_EXISTING) != FR_OK)
+        return 1;
+    f_lseek(&file, 0x110);
+    f_read(&file, movable_keyy, 0x10, &btr);
+    f_close(&file);
+    if (btr != 0x10)
+        return 1;
+
+    // build the seed save path
+    sha_quick(sha256sum, movable_keyy, 0x10, SHA256_MODE);
+    snprintf(path, 128, "%2.2s/data/%08lX%08lX%08lX%08lX/sysdata/0001000F/00000000",
+        drv, sha256sum[0], sha256sum[1], sha256sum[2], sha256sum[3]);
+
+    return 0;
+}
+
+u32 FindSeed(u8* seed, u64 titleId, u32 hash_seed) {
+    static u8 lseed[16+8] __attribute__((aligned(4))) = { 0 }; // seed plus title ID for easy validation
+    u32 sha256sum[8];
+
+    memcpy(lseed+16, &titleId, 8);
+    sha_quick(sha256sum, lseed, 16 + 8, SHA256_MODE);
+    if (hash_seed == sha256sum[0]) {
+        memcpy(seed, lseed, 16);
+        return 0;
+    }
+
+    // setup a large enough buffer
+    u8* buffer = (u8*) malloc(max(STD_BUFFER_SIZE, sizeof(SeedDb)));
+    if (!buffer) return 1;
+    
+    // try to grab the seed from NAND database
+    const char* nand_drv[] = {"1:", "4:"}; // SysNAND and EmuNAND
+    for (u32 i = 0; i < countof(nand_drv); i++) {
+        char path[128];
+        SeedDb* seeddb = (SeedDb*) (void*) buffer;
+
+        // read SEEDDB from file
+        if (GetSeedPath(path, nand_drv[i]) != 0) continue;
+        if ((ReadDisaDiffIvfcLvl4(path, NULL, SEEDSAVE_AREA_OFFSET, sizeof(SeedDb), seeddb) != sizeof(SeedDb)) ||
+        	(seeddb->n_entries > SEEDSAVE_MAX_ENTRIES))
+            continue;
+
+        // search for the seed
+        for (u32 s = 0; s < seeddb->n_entries; s++) {
+            if (titleId != seeddb->titleId[s]) continue;
+            memcpy(lseed, &(seeddb->seed[s]), sizeof(Seed));
+            sha_quick(sha256sum, lseed, 16 + 8, SHA256_MODE);
+            if (hash_seed == sha256sum[0]) {
+                memcpy(seed, lseed, 16);
+                free(buffer);
+                return 0; // found!
+            }
+        }
+    }
+	
+	// not found -> try seeddb.bin
+    SeedInfo* seeddb = (SeedInfo*) (void*) buffer;
+    size_t len = LoadSupportFile(SEEDINFO_NAME, seeddb, STD_BUFFER_SIZE);
+    if (len && (seeddb->n_entries <= (len - 16) / 32)) { // check filesize / seeddb size
+        for (u32 s = 0; s < seeddb->n_entries; s++) {
+            if (titleId != seeddb->entries[s].titleId)
+                continue;
+            memcpy(lseed, &(seeddb->entries[s].seed), sizeof(Seed));
+            sha_quick(sha256sum, lseed, 16 + 8, SHA256_MODE);
+            if (hash_seed == sha256sum[0]) {
+                memcpy(seed, lseed, 16);
+                free(buffer);
+                return 0; // found!
+            }
+        }
+    }
+
+    // out of options -> failed!
+    free(buffer);
+    return 1;
+}
+
+u32 AddSeedToDb(SeedInfo* seed_info, SeedInfoEntry* seed_entry) {
+    if (!seed_entry) { // no seed entry -> reset database
+        memset(seed_info, 0, 16);
+        return 0;
+    }
+    // check if entry already in DB
+    u32 n_entries = seed_info->n_entries;
+    SeedInfoEntry* seed = seed_info->entries;
+    for (u32 i = 0; i < n_entries; i++, seed++)
+        if (seed->titleId == seed_entry->titleId) return 0;
+    // actually a new seed entry
+    memcpy(seed, seed_entry, sizeof(SeedInfoEntry));
+    seed_info->n_entries++;
+    return 0;
+}
+
+u32 InstallSeedDbToSystem(SeedInfo* seed_info, bool to_emunand) {
+    char path[128];
+    SeedDb* seeddb = (SeedDb*) malloc(sizeof(SeedDb));
+    if (!seeddb) return 1;
+
+    // read the current SEEDDB database
+    if ((GetSeedPath(path, to_emunand ? "4:" : "1:") != 0) ||
+        (ReadDisaDiffIvfcLvl4(path, NULL, SEEDSAVE_AREA_OFFSET, sizeof(SeedDb), seeddb) != sizeof(SeedDb)) ||
+        (seeddb->n_entries >= SEEDSAVE_MAX_ENTRIES)) {
+        free (seeddb);
+        return 1;
+    }
+
+    // find free slots, insert seeds from SeedInfo
+    for (u32 slot = 0, s = 0; s < seed_info->n_entries; s++) {
+        SeedInfoEntry* entry = &(seed_info->entries[s]);
+        for (slot = 0; slot < seeddb->n_entries; slot++)
+            if (seeddb->titleId[slot] == entry->titleId) break;
+        if (slot >= SEEDSAVE_MAX_ENTRIES) break;
+        if (slot >= seeddb->n_entries) seeddb->n_entries = slot + 1;
+        seeddb->titleId[slot] = entry->titleId;
+        memcpy(&(seeddb->seed[slot]), &(entry->seed), sizeof(Seed));
+    }
+
+    // write back to system (warning: no write protection checks here)
+    u32 size = WriteDisaDiffIvfcLvl4(path, NULL, SEEDSAVE_AREA_OFFSET, sizeof(SeedDb), seeddb);
+    FixFileCmac(path, false);
+
+    free (seeddb);
+    return (size == sizeof(SeedDb)) ? 0 : 1;
+}
+
+u32 SetupSeedPrePurchase(u64 titleId, bool to_emunand) {
+	// here, we ask the system to install the seed for us
+	TitleTag* titletag = (TitleTag*) malloc(sizeof(TitleTag));
+	if (!titletag) return 1;
+	
+	char path[128];
+	if ((GetSeedPath(path, to_emunand ? "4:" : "1:") != 0) ||
+        (ReadDisaDiffIvfcLvl4(path, NULL, TITLETAG_AREA_OFFSET, sizeof(TitleTag), titletag) != sizeof(TitleTag)) ||
+        (titletag->n_entries >= TITLETAG_MAX_ENTRIES)) {
+    	free (titletag);
+        return 1;
+    }
+    
+    // pointers for TITLETAG title IDs and seeds
+	// find a free slot, insert titletag
+	u32 slot = 0;
+	for (; slot < titletag->n_entries; slot++)
+		if (titletag->titleId[slot] == titleId) break;
+	if (slot >= titletag->n_entries)
+		titletag->n_entries = slot + 1;
+	
+	TitleTagEntry* ttag = &(titletag->tag[slot]);
+	titletag->titleId[slot] = titleId;
+	memset(ttag, 0, sizeof(TitleTagEntry));
+	memcpy(ttag->magic, "PREP", 4);
+	ttag->year = 2000;
+	ttag->month = 1;
+	ttag->day = 1;
+	ttag->country_code = 1;
+
+    // write back to system (warning: no write protection checks here)
+	u32 size = WriteDisaDiffIvfcLvl4(path, NULL, TITLETAG_AREA_OFFSET, sizeof(TitleTag), titletag);
+	FixFileCmac(path, false);
+	
+	free(titletag);
+	return (size == sizeof(TitleTag)) ? 0 : 1;
+}
+
+u32 SetupSeedSystemCrypto(u64 titleId, u32 hash_seed, bool to_emunand) {
+	// attempt to find the seed inside the seeddb.bin support file
+	SeedInfo* seeddb = (SeedInfo*) malloc(STD_BUFFER_SIZE);
+	if (!seeddb) return 1;
+
+	size_t len = LoadSupportFile(SEEDINFO_NAME, seeddb, STD_BUFFER_SIZE);
+    if (len && (seeddb->n_entries <= (len - 16) / 32)) { // check filesize / seeddb size
+        for (u32 s = 0; s < seeddb->n_entries; s++) {
+            if (titleId != seeddb->entries[s].titleId)
+                continue;
+            // found a candidate, hash and verify it
+            u8 lseed[16+8] __attribute__((aligned(4))) = { 0 }; // seed plus title ID for easy validation
+            u32 sha256sum[8];
+            memcpy(lseed+16, &titleId, 8);
+            memcpy(lseed, &(seeddb->entries[s].seed), sizeof(Seed));
+            sha_quick(sha256sum, lseed, 16 + 8, SHA256_MODE);
+            u32 res = 0; // assuming the installed seed to be correct
+            if (hash_seed == sha256sum[0]) {
+            	// found, install it
+                seeddb->n_entries = 1;
+                seeddb->entries[0].titleId = titleId;
+                memcpy(&(seeddb->entries[0].seed), lseed, sizeof(Seed));
+                res = InstallSeedDbToSystem(seeddb, to_emunand);
+            }
+            free(seeddb);
+            return res;
+        }
+    }
+
+    free(seeddb);
+	return 1;
+}

--- a/arm9/source/game/seedsave.h
+++ b/arm9/source/game/seedsave.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "common.h"
+#include "disadiff.h"
+
+#define SEEDINFO_NAME         "seeddb.bin"
+#define SEEDINFO_SIZE(sdb)    (16 + ((sdb)->n_entries * sizeof(SeedInfoEntry)))
+
+#define SEEDSAVE_MAX_ENTRIES  2000
+#define SEEDSAVE_AREA_OFFSET  0x3000
+
+typedef struct {
+	u8 byte[16];
+} PACKED_STRUCT Seed;
+
+typedef struct {
+    u64 titleId;
+    Seed seed;
+    u8 reserved[8];
+} PACKED_STRUCT SeedInfoEntry;
+
+typedef struct {
+    u32 n_entries;
+    u8 padding[12];
+    SeedInfoEntry entries[SEEDSAVE_MAX_ENTRIES]; // this number is only a placeholder
+} PACKED_STRUCT SeedInfo;
+
+typedef struct {
+	u32 unknown0;
+	u32 n_entries;
+	u8  unknown1[0x1000 - 0x8];
+	u64 titleId[SEEDSAVE_MAX_ENTRIES];
+	Seed seed[SEEDSAVE_MAX_ENTRIES];
+} PACKED_STRUCT SeedDb;
+
+u32 GetSeedPath(char* path, const char* drv);
+u32 FindSeed(u8* seed, u64 titleId, u32 hash_seed);
+u32 AddSeedToDb(SeedInfo* seed_info, SeedInfoEntry* seed_entry);
+u32 InstallSeedDbToSystem(SeedInfo* seed_info, bool to_emunand);
+u32 SetupSeedPrePurchase(u64 titleId, bool to_emunand);
+u32 SetupSeedSystemCrypto(u64 titleId, u32 hash_seed, bool to_emunand);

--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -2112,7 +2112,7 @@ u32 HomeMoreMenu(char* current_path) {
         bool seed_sys = false;
         bool seed_emu = false;
         if (BuildSeedInfo(NULL, false) == 0) {
-            ShowString("Building " SEEDDB_NAME "...");
+            ShowString("Building " SEEDINFO_NAME "...");
             seed_sys = (BuildSeedInfo("1:", false) == 0);
             seed_emu = (BuildSeedInfo("4:", false) == 0);
             if (!seed_sys || BuildSeedInfo(NULL, true) != 0)
@@ -2121,7 +2121,7 @@ u32 HomeMoreMenu(char* current_path) {
         ShowPrompt(false, "Built in " OUTPUT_PATH ":\n \n%18.18-s %s\n%18.18-s %s\n%18.18-s %s",
             TIKDB_NAME_ENC, tik_enc_sys ? tik_enc_emu ? "OK (Sys&Emu)" : "OK (Sys)" : "Failed",
             TIKDB_NAME_DEC, tik_dec_sys ? tik_dec_emu ? "OK (Sys&Emu)" : "OK (Sys)" : "Failed",
-            SEEDDB_NAME, seed_sys ? seed_emu ? "OK (Sys&Emu)" : "OK (Sys)" : "Failed");
+            SEEDINFO_NAME, seed_sys ? seed_emu ? "OK (Sys&Emu)" : "OK (Sys)" : "Failed");
         GetDirContents(current_dir, current_path);
         return 0;
     }

--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -691,7 +691,7 @@ u32 FileHexViewer(const char* path) {
                 marked0 = (s32) found_offset - (offset + curr_pos);
                 marked1 = marked0 + found_size;
                 if (marked0 < 0) marked0 = 0;
-                if (marked1 > cols) marked1 = cols;
+                if (marked1 > (s32) cols) marked1 = (s32) cols;
             }
 
             // switch to bottom screen
@@ -710,7 +710,7 @@ u32 FileHexViewer(const char* path) {
                 COLOR_STD_BG, "%08X", (unsigned int) offset + curr_pos);
             if (x_ascii >= 0) {
                 DrawString(screen, ascii, x_ascii - x0, y, COLOR_HVASCII, COLOR_STD_BG, false);
-                for (u32 i = marked0; i < marked1; i++)
+                for (u32 i = (u32) marked0; i < (u32) marked1; i++)
                     DrawCharacter(screen, ascii[i % cols], x_ascii - x0 + (FONT_WIDTH_EXT * i), y, COLOR_MARKED, COLOR_STD_BG);
                 if (edit_mode && ((u32) cursor / cols == row)) DrawCharacter(screen, ascii[cursor % cols],
                     x_ascii - x0 + FONT_WIDTH_EXT * (cursor % cols), y, COLOR_RED, COLOR_STD_BG);
@@ -720,7 +720,7 @@ u32 FileHexViewer(const char* path) {
             for (u32 col = 0; (col < cols) && (x_hex >= 0); col++) {
                 u32 x = (x_hex + hlpad) + (((2*FONT_WIDTH_EXT) + hrpad + hlpad) * col) - x0;
                 u32 hex_color = (edit_mode && ((u32) cursor == curr_pos + col)) ? COLOR_RED :
-                    ((col >= marked0) && (col < marked1)) ? COLOR_MARKED : COLOR_HVHEX(col);
+                    (((s32) col >= marked0) && ((s32) col < marked1)) ? COLOR_MARKED : COLOR_HVHEX(col);
                 if (col < cutoff)
                     DrawStringF(screen, x, y, hex_color, COLOR_STD_BG, "%02X", (unsigned int) data[curr_pos + col]);
                 else DrawStringF(screen, x, y, hex_color, COLOR_STD_BG, "  ");

--- a/arm9/source/utils/gameutil.c
+++ b/arm9/source/utils/gameutil.c
@@ -1433,7 +1433,9 @@ u32 UninstallGameData(u64 tid64, bool remove_tie, bool remove_ticket, bool remov
     // clear leftovers
     if (GetInstallPath(path_data, drv, tid64, NULL, NULL) != 0)
         fvx_unlink(path_data);
-    // system save is *not* cleared in any case (!!!)
+
+    // rmeove save (additional step required for system titles)
+    CreateSaveData(drv, tid64, NULL, 0, true);
 
     // remove titledb entry / ticket
     u32 ret = 0;

--- a/arm9/source/utils/gameutil.c
+++ b/arm9/source/utils/gameutil.c
@@ -1838,8 +1838,8 @@ u32 InstallFromCiaFile(const char* path_cia, const char* path_dest) {
     if (getbe32(cia->ticket.console_id) != (&ARM9_ITCM->otp)->deviceId)
         memset(cia->ticket.console_id, 0x00, 4);
 
-    // fix TMD hashes, install CIA system data
-    if ((FixTmdHashes(&(cia->tmd)) != 0) ||
+    // verify TMD hashes, install CIA system data
+    if ((VerifyTmd(&(cia->tmd)) != 0) ||
         (InstallCiaSystemData(cia, path_dest) != 0)) {
         free(cia);
         return 1;
@@ -2019,8 +2019,8 @@ u32 BuildInstallFromTmdFileBuffered(const char* path_tmd, const char* path_dest,
         }
     }
 
-    // write the CIA stub (take #2)
-    if ((FixTmdHashes(tmd) != 0) ||
+    // verify TMD / write CIA stub / install system data (take #2)
+    if ((VerifyTmd(tmd) != 0) ||
         (!install && (WriteCiaStub(cia, path_dest) != 0)) ||
         (install && (InstallCiaSystemData(cia, path_dest) != 0)))
         return 1;

--- a/arm9/source/utils/scripting.c
+++ b/arm9/source/utils/scripting.c
@@ -1363,8 +1363,8 @@ bool run_cmd(cmd_id id, u32 flags, char** argv, char* err_str) {
                     (BuildTitleKeyInfo(NULL, tik_dec, true) == 0))
                     ret = true;
             }
-        } else if (strncasecmp(argv[0], SEEDDB_NAME, _ARG_MAX_LEN) == 0) {
-            if (flags & _FLG('w')) fvx_unlink(OUTPUT_PATH "/" SEEDDB_NAME);
+        } else if (strncasecmp(argv[0], SEEDINFO_NAME, _ARG_MAX_LEN) == 0) {
+            if (flags & _FLG('w')) fvx_unlink(OUTPUT_PATH "/" SEEDINFO_NAME);
             if (BuildSeedInfo(NULL, false) == 0) {
                 ShowString("Building to " OUTPUT_PATH ":\n%s ...", argv[0]);
                 if (((BuildSeedInfo("1:", false) == 0) ||

--- a/common/types.h
+++ b/common/types.h
@@ -24,10 +24,10 @@ typedef uint16_t u16;
 typedef uint32_t u32;
 typedef uint64_t u64;
 
-typedef int64_t s8;
-typedef int64_t s16;
-typedef int64_t s32;
-typedef int64_t s64;
+typedef int8_t   s8;
+typedef int16_t  s16;
+typedef int32_t  s32;
+typedef int64_t  s64;
 
 typedef volatile u8 vu8;
 typedef volatile u16 vu16;


### PR DESCRIPTION
This is a followup pull request to already merged #618. Based on the tests done previously by @TurdPooCharger (again, thanks a lot!), this is the current state:


**Presumably fixed**
Fixed, and tested at least once. Further testing makes sense here, cause we may still have missed something.
* bad CMD file without CMACs (see test 1): Should be fixed for good. Only system CMDs have no CMACs.
* `title.db` entry, bytes 0x0C...0x0 (see test 1): "title version" - takes over NCCH title version too for NCCH with DLP only (thanks @ihaveamac)
* cleanup of orphaned files from earlier installs (see test 2): Before an install, we wipe the `content/data` folder now. Existing saves with the correct size are left untouched.
* ticket device ID is always set to zero (see test 3): We keep the device ID if it matches the system now. It is zeroed only where required.
* savegames for TWL are not auto-created (see test 4): This is implemented now. The save files won't match system created ones exactly (in fact, only the first 0x200 byte should be identical for `public.sav` and `private.sav`), but it should still work. We are unsure if `banner.sav` also work. Further testing is required.
* `title.db` entry, bytes 0x20...0x23 (see test 5): "extdata id low" - this is now properly taken over


**Unfixed / Unfixable**
Stuff that we lack the knowledge for fixing. Some of these are "non-errors" and rather stuff that system / FBI does different from GM9. None of these has an effect on functionality.
* `title.db` entry, bytes 0x50...0x53 (see test 1): "mystery bytes" - we just write "GM9" there. Causes no problems at all. We'd very much like to do this proper, though.
* `title.db` entry, bytes 0x14...0x1D (see test 2): "TMD ID" and "CMD ID" - we always use 0 / 1 for this. This is not an error, but rather a slightly different approach. Won't be fixed.
* `title.db` entry, bytes 0x00...0x03 and 0x30...0x3F for `DS INTERNET` (see test 3) - we have no clue what happens here. Values seem random.
* Difference in ticket between CIA install and .3DS install (see test 5): No clue what happens here yet, but no effect on functionality. I think @aspargas2 may have a better understanding of how this happens than me.


**Other**
This category is for other stuff that was observed during the tests.
* Out of memory error when swapping out the `Nintendo 3DS` folder (see test 1): This can cause problems. We will research this, but it does not have high priority.
* Software keyboard does not work (see test 3): Fixed by @Wolfvak - thanks!