### PR TITLE
Fix dumping of TWL ROM images flashed to NTR dev carts

### DIFF
--- a/arm9/source/gamecart/gamecart.c
+++ b/arm9/source/gamecart/gamecart.c
@@ -240,6 +240,20 @@ u32 ReadCartPrivateHeader(void* buffer, u64 offset, u64 count, CartData* cdata) 
     return 0;
 }
 
+u32 ReadCartId(u8* buffer, u64 offset, u64 count, CartData* cdata) {
+    u8 ownBuf[GAMECART_ID_SIZE] = { 0 };
+    u32 id;
+    u8 sReg;
+    if (offset >= GAMECART_ID_SIZE) return 1;
+    if (offset + count > GAMECART_ID_SIZE) count = GAMECART_ID_SIZE - offset;
+    ownBuf[0] = (cdata->cart_id >> 24) & 0xff;
+    ownBuf[1] = (cdata->cart_id >> 16) & 0xff;
+    ownBuf[2] = (cdata->cart_id >>  8) & 0xff;
+    ownBuf[3] = cdata->cart_id & 0xff;
+    memcpy(buffer, ownBuf + offset, count);
+    return 0;
+}
+
 u32 ReadCartSave(u8* buffer, u64 offset, u64 count, CartData* cdata) {
     if (offset >= cdata->save_size) return 1;
     if (offset + count > cdata->save_size) count = cdata->save_size - offset;

--- a/arm9/source/gamecart/gamecart.c
+++ b/arm9/source/gamecart/gamecart.c
@@ -144,9 +144,14 @@ u32 InitCartRead(CartData* cdata) {
             if ((cdata->arm9i_rom_offset < nds_header->ntr_rom_size) ||
                 (cdata->arm9i_rom_offset + MODC_AREA_SIZE > cdata->data_size))
                 return 1; // safety first
-            Cart_Init();
-            NTR_CmdReadHeader(cdata->twl_header);
-            if (!NTR_Secure_Init(cdata->twl_header, Cart_GetID(), 1)) return 1;
+
+            // Some NTR dev carts have TWL ROMs flashed to them.
+            // We'll only want to use TWL secure init if this is a TWL cartridge.
+            if (cdata->cart_id & 0x40000000U) { // TWL cartridge
+                Cart_Init();
+                NTR_CmdReadHeader(cdata->twl_header);
+                if (!NTR_Secure_Init(cdata->twl_header, Cart_GetID(), 1)) return 1;
+            }
         }
 
         // last safety check

--- a/arm9/source/gamecart/gamecart.h
+++ b/arm9/source/gamecart/gamecart.h
@@ -11,6 +11,7 @@
 #define MODC_AREA_SIZE          0x4000
 #define PRIV_HDR_SIZE           0x50
 #define JEDECID_AND_SREG_SIZE   0x4
+#define GAMECART_ID_SIZE        0x4
 
 typedef struct {
     u8  header[0x8000]; // NTR header + secure area / CTR header + private header
@@ -29,6 +30,7 @@ u32 InitCartRead(CartData* cdata);
 u32 ReadCartSectors(void* buffer, u32 sector, u32 count, CartData* cdata);
 u32 ReadCartBytes(void* buffer, u64 offset, u64 count, CartData* cdata);
 u32 ReadCartPrivateHeader(void* buffer, u64 offset, u64 count, CartData* cdata);
+u32 ReadCartId(u8* buffer, u64 offset, u64 count, CartData* cdata);
 u32 ReadCartSave(u8* buffer, u64 offset, u64 count, CartData* cdata);
 u32 WriteCartSave(const u8* buffer, u64 offset, u64 count, CartData* cdata);
 u32 ReadCartSaveJedecId(u8* buffer, u64 offset, u64 count, CartData* cdata);


### PR DESCRIPTION
We've encountered a few NTR dev cartridges that have TWL-enhanced ROM images flashed to them. These cartridges work fine on a Nintendo DS, and on some 3DS units. Attempting to dump them with GodMode9 (and wooddumper) fails because the ROM header indicates that the cartridge is TWL-enhanced, but the NTR dev cart doesn't support the TWL secure area init command (0x3D), so TWL key exchange fails.

This PR checks the TWL flag in the chip ID. If it's not present, then it won't attempt to use TWL secure area init, even if the TWL flag is set in the ROM header.

We're also using the ROM size value in the chip ID now for the full cartridge size if it's present. If not, it falls back to using the ROM header value.