### PR TITLE
Fix uninitialized variable on unaligned SPI Xfer

### DIFF
--- a/common/spi.c
+++ b/common/spi.c
@@ -103,7 +103,7 @@ static void SPI_SingleXfer(u32 reg, u32 bus, void *buffer, u32 len, bool read)
 				u32 tmp = REG_SPI(bus, REG_SPI_FIFO);
 				memcpy((u8 *) buffer + pos, &tmp, min(4, len - pos));
 			} else {
-				u32 tmp;
+				u32 tmp = 0;
 				memcpy(&tmp, (u8 *) buffer + pos, min(4, len - pos));
 				REG_SPI(bus, REG_SPI_FIFO) = tmp;
 			}


### PR DESCRIPTION
We use a stack-allocated u32 to store a temporary word that gets memcpy'd from a potentially unaligned buffer, but the size of the copy could be less than 4 bytes, therefore leaving garbage in the upper bits of said word. This fixes CODEC in Corgi3DS.