### PR TITLE
Include scripts in ntr firms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ export COMMON_DIR := ../common
 VRAM_OUT    := $(OUTDIR)/vram0.tar
 VRAM_DATA   := data
 VRAM_FLAGS  := --make-new --path-limit 99 --size-limit 262144
+ifeq ($(NTRBOOT),1)
+	VRAM_SCRIPTS := resources/gm9/scripts
+endif
 
 ifeq ($(OS),Windows_NT)
 	ifeq ($(TERM),cygwin)
@@ -80,7 +83,7 @@ release: clean unmarked_readme
 vram0:
 	@mkdir -p "$(OUTDIR)"
 	@echo "Creating $(VRAM_OUT)"
-	@$(PY3) utils/add2tar.py $(VRAM_FLAGS) $(VRAM_OUT) $(shell ls -d $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA)/*)
+	@$(PY3) utils/add2tar.py $(VRAM_FLAGS) $(VRAM_OUT) $(shell ls -d $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA)/* $(VRAM_SCRIPTS))
 
 %.elf: .FORCE
 	@echo "Building $@"


### PR DESCRIPTION
Unless the SD card happens to both be accessible and contain a
`gm9/scripts` directory, a system booted with a NTR cartridge isn't going
to have access to the stock scripts and will just show an error upon
going to the menu and selecting `Scripts...`.  This patch adds scripts
to the vram tarball only for ntr builds so they can be available even
on completely untouched systems.  It shouldn't be necessary when we've
booted from something else because in those cases we've already written
GodMode9.firm to flash using some other means and could have copied all
the scripts then.

One might argue this is sub-optimal because the menu will point there
even if a scripts directory happens to exist on the SD card.  One might
instead argue that that behavior is preferable because there's no telling
what gm9 version the scripts on the SD card were intended for.