### PR TITLE
Fix NDS / DSi names being cut off when renaming to good name

### DIFF
--- a/arm9/source/utils/gameutil.c
+++ b/arm9/source/utils/gameutil.c
@@ -4014,8 +4014,15 @@ u32 GetGoodName(char* name, const char* path, bool quick) {
         } else {
             char title_name[0x80+1] = { 0 };
             if (GetTwlTitle(title_name, (TwlIconData*) icon) != 0) return 1;
-            char* linebrk = strchr(title_name, '\n');
+            char* linebrk = strrchr(title_name, '\n'); // search for the last occurence of newline, because everything until the last newline is part of the name
+
             if (linebrk) *linebrk = '\0';
+
+            for (char *c = title_name; *c; c++) {
+                if (*c == "\n") {
+                    *c = " "; //replace any remaining newlines with a space, to merge the parts
+                }
+            }
 
             if (twl->unit_code & 0x02) { // TWL
                 char region[8] = { 0 };


### PR DESCRIPTION
To better understand what this fixes, let's take a look at what happens when renaming this NDS file to good name:
![og_prompt](https://user-images.githubusercontent.com/18742654/124441149-10ab1080-dd84-11eb-8408-d90917edb620.png)
![og_result](https://user-images.githubusercontent.com/18742654/124441182-19034b80-dd84-11eb-93be-f20176f6a1ec.png)

The result is a cut-off name, because currently, the name is copied *only until the first newline*.
NDS/DSi Names consist of `Title + Publisher` in one string. However, to avoid overlapping, parts of the Title and the Publisher are separated by newlines, as seen here:
![grafik](https://user-images.githubusercontent.com/18742654/124441566-78f9f200-dd84-11eb-8946-b65c87fa2e8d.png)

and this is what the Title looks like, if we were to interpret it as a string:
```c
"Professor Kageyama's\nMaths Training\nNINTENDO"
```
Therefore, __every character until the last newline is still part of the Title, because what comes after the last newline is the Publisher__.

I have implemented it like this:
1. Instead of checking for the **first** occurrence of a newline, I'm checking for the **last** ocurrence of a newline, to know where the Title stops and the Publisher starts.
2. Looping through the Title and replacing every remaining newline with a space to merge all possible parts together, forming the correct Title.

And as a result:
![fix_prompt](https://user-images.githubusercontent.com/18742654/124442624-9aa7a900-dd85-11eb-8118-1443df12cea7.png)
![fix_result](https://user-images.githubusercontent.com/18742654/124442649-a004f380-dd85-11eb-84a3-d0d06cf6631e.png)
It now correctly renames the Title, it is no longer cut off.