### PR TITLE
Preserve RSA keys in trimmed NTR dumps

### DIFF
--- a/arm9/source/gamecart/gamecart.c
+++ b/arm9/source/gamecart/gamecart.c
@@ -246,7 +246,7 @@ u32 InitCartRead(CartData* cdata) {
         if (nds_header->device_capacity >= 15) return 1; // too big, not valid
         if (cdata->cart_size == 0)
             cdata->cart_size = (128 * 1024) << nds_header->device_capacity;
-        cdata->data_size = nds_header->ntr_rom_size;
+        cdata->data_size = nds_header->ntr_rom_size + 0x88;
         cdata->arm9i_rom_offset = 0;
 
         // TWL header

--- a/arm9/source/gamecart/gamecart.c
+++ b/arm9/source/gamecart/gamecart.c
@@ -246,8 +246,6 @@ u32 InitCartRead(CartData* cdata) {
         if (nds_header->device_capacity >= 15) return 1; // too big, not valid
         if (cdata->cart_size == 0)
             cdata->cart_size = (128 * 1024) << nds_header->device_capacity;
-		// safety check for 0x88 addition
-		if (cdata->data_size > nds_header->ntr_rom_size + 0x88) return 1;
         cdata->data_size = nds_header->ntr_rom_size + 0x88;
         cdata->arm9i_rom_offset = 0;
 

--- a/arm9/source/gamecart/gamecart.c
+++ b/arm9/source/gamecart/gamecart.c
@@ -246,6 +246,8 @@ u32 InitCartRead(CartData* cdata) {
         if (nds_header->device_capacity >= 15) return 1; // too big, not valid
         if (cdata->cart_size == 0)
             cdata->cart_size = (128 * 1024) << nds_header->device_capacity;
+		// safety check for 0x88 addition
+		if (cdata->data_size > nds_header->ntr_rom_size + 0x88) return 1;
         cdata->data_size = nds_header->ntr_rom_size + 0x88;
         cdata->arm9i_rom_offset = 0;
 


### PR DESCRIPTION
Fixes #721, implemented exactly as described in the issue.

This was tested on a Mario Kart DS (Korea) cartridge, while being played on nds-bootstrap and an original R4, where cloneboot requires the RSA key. It is useful for real hardware NDS playback as a whole.

I unfortunately do not have a TWL cart to test the fix there. If anyone else is willing to test, or have any suggestions about what to add to this PR, feel free to let me know or directly commit.