### PR TITLE
Make TWL MBR check actually give useful info

### DIFF
--- a/arm9/source/utils/nandutil.c
+++ b/arm9/source/utils/nandutil.c
@@ -342,7 +342,7 @@ u32 ValidateNandDump(const char* path) {
 
     // check TWL & CTR FAT partitions
     for (u32 i = 0; i < 2; i++) {
-        char* section_type = (i) ? "CTR" : "MBR";
+        char* section_type = (i) ? "CTR" : "TWL";
         if (i == 0) { // check TWL first, then CTR
             if (GetNandNcsdPartitionInfo(&info, NP_TYPE_STD, NP_SUBTYPE_TWL, 0, &ncsd) != 0) return 1;
         } else if ((GetNandNcsdPartitionInfo(&info, NP_TYPE_STD, NP_SUBTYPE_CTR, 0, &ncsd) != 0) &&


### PR DESCRIPTION
Currently, if TWL MBR is corrupt, the error shows "Error: MBR MBR is corrupt", while CTR MBR being incorrect shows "Error: CTR MBR is corrupt". This changes this to match the error style given for CTR MBR errors.