### PR TITLE
Add a new type of flash chip, from Art Academy

### DIFF
--- a/arm9/source/gamecart/card_spi.c
+++ b/arm9/source/gamecart/card_spi.c
@@ -88,6 +88,9 @@ const CardSPITypeData flashTypes[] = {
 
     // This is the most common type of flash 3DS cartridges. Not normally found in DS ones, but check anyway. (Custom MXIC chips)
     { CardSPIEnableWriting_regular, CardSPIReadSaveData_24bit, CardSPIWriteSaveData_24bit_erase_program, CardSPIEraseSector_real, 0xC222, 0, 4096, 32, 4096, SPI_FLASH_CMD_PW, SPI_CMD_PP, SPI_FLASH_CMD_MXIC_SE },
+
+    // Found this in some copies of ArtAcademy, I think it's something from MXIC (Thank you for the help @FerozElMejor on Discord)
+    { CardSPIEnableWriting_regular, CardSPIReadSaveData_24bit, CardSPIWriteSaveData_24bit_erase_program, CardSPIEraseSector_real, 0xC220, 0, 4096, 32, 4096, SPI_FLASH_CMD_PW, SPI_CMD_PP, SPI_FLASH_CMD_MXIC_SE },
 };
 
 const CardSPITypeData * const FLASH_CTR_GENERIC = flashTypes + 5;
@@ -167,7 +170,7 @@ int _SPIWriteTransaction(CardSPIType type, void* cmd, u32 cmdSize, const void* d
     int res;
     if ((res = CardSPIEnableWriting(type))) return res;
     if ((res = CardSPIWriteRead(type.infrared, cmd, cmdSize, NULL, 0, (void*) ((u8*) data), dataSize))) return res;
-    return CardSPIWaitWriteEnd(type.infrared, 1000);
+    return CardSPIWaitWriteEnd(type.infrared, 10000);
 }
 
 int CardSPIReadJEDECIDAndStatusReg(bool infrared, u32* id, u8* statusReg) {


### PR DESCRIPTION
Yesterday evening, Discord user FerozElMejor has discovered a new kind of save chip in a copy of Art Academy. With @Epicpkmn11's help, we have surmised its JEDEC ID is `0xC22017`, and based on that it's manufactured by Macronix. We have tested the write settings as in the commit, and they seem to work too.

The one other notable change is changing the timeout on the program operation. This seemed necessary for FerozElMajor's cartridge.