### PR TITLE
Add user-facing SHA1 support

### DIFF
--- a/arm9/source/filesys/fsutil.h
+++ b/arm9/source/filesys/fsutil.h
@@ -7,12 +7,13 @@
 #define NO_CANCEL       (1UL<<1)
 #define SILENT          (1UL<<2)
 #define CALC_SHA        (1UL<<3)
-#define BUILD_PATH      (1UL<<4)
-#define ALLOW_EXPAND    (1UL<<5)
-#define ASK_ALL         (1UL<<6)
-#define SKIP_ALL        (1UL<<7)
-#define OVERWRITE_ALL   (1UL<<8)
-#define APPEND_ALL      (1UL<<9)
+#define USE_SHA1        (1UL<<4)
+#define BUILD_PATH      (1UL<<5)
+#define ALLOW_EXPAND    (1UL<<6)
+#define ASK_ALL         (1UL<<7)
+#define SKIP_ALL        (1UL<<8)
+#define OVERWRITE_ALL   (1UL<<9)
+#define APPEND_ALL      (1UL<<10)
 
 // file selector flags
 #define NO_DIRS         (1UL<<0)
@@ -43,7 +44,7 @@ size_t FileGetData(const char* path, void* data, size_t size, size_t foffset);
 size_t FileGetSize(const char* path);
 
 /** Get SHA-256 of file **/
-bool FileGetSha256(const char* path, u8* sha256, u64 offset, u64 size);
+bool FileGetSha(const char* path, u8* hash, u64 offset, u64 size, bool sha1);
 
 /** Find data in file **/
 u32 FileFindData(const char* path, u8* data, u32 size_data, u32 offset_file);

--- a/arm9/source/utils/gameutil.c
+++ b/arm9/source/utils/gameutil.c
@@ -895,7 +895,7 @@ u32 VerifyTadFile(const char* path) {
         u8 hash[32];
         u32 len = align(hdr->content_size[i], 0x10);
         if (!len) continue; // non-existant section
-        if (!FileGetSha256(path, hash, content_start, len) ||
+        if (!FileGetSha(path, hash, content_start, len, false) ||
             (memcmp(hash, ftr->content_sha256[i], 32) != 0))
             return 1;
         content_start += len + sizeof(TadBlockMetaData);


### PR DESCRIPTION
This PR adds an option in the GUI to calculate the SHA-1 hash of any file, and adds a `-1` flag to the `sha`, `shaget`, and `cp -h` scripting commands to use SHA-1 instead of the default SHA-256. It also allows for characters `'0'` through `'5'` to be used as flags for scripting commands, and fixes a bug in the scripting engine where `err_str` would not be set if an invalid character was passed as a flag.