### PR TITLE
fix #729

### DIFF
--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -2166,8 +2166,9 @@ u32 HomeMoreMenu(char* current_path) {
         bool tik_enc_sys = false;
         bool tik_enc_emu = false;
         if (BuildTitleKeyInfo(NULL, false, false) == 0) {
-            ShowString("Building " TIKDB_NAME_ENC "...");
+            ShowString("Building " TIKDB_NAME_ENC " (SysNAND)...");
             tik_enc_sys = (BuildTitleKeyInfo("1:/dbs/ticket.db", false, false) == 0);
+            ShowString("Building " TIKDB_NAME_ENC " (EmuNAND)...");
             tik_enc_emu = (BuildTitleKeyInfo("4:/dbs/ticket.db", false, false) == 0);
             if (!tik_enc_sys || BuildTitleKeyInfo(NULL, false, true) != 0)
                 tik_enc_sys = tik_enc_emu = false;
@@ -2175,8 +2176,9 @@ u32 HomeMoreMenu(char* current_path) {
         bool tik_dec_sys = false;
         bool tik_dec_emu = false;
         if (BuildTitleKeyInfo(NULL, true, false) == 0) {
-            ShowString("Building " TIKDB_NAME_DEC "...");
+            ShowString("Building " TIKDB_NAME_DEC " (SysNAND)...");
             tik_dec_sys = (BuildTitleKeyInfo("1:/dbs/ticket.db", true, false) == 0);
+            ShowString("Building " TIKDB_NAME_DEC " (EmuNAND)...");
             tik_dec_emu = (BuildTitleKeyInfo("4:/dbs/ticket.db", true, false) == 0);
             if (!tik_dec_sys || BuildTitleKeyInfo(NULL, true, true) != 0)
                 tik_dec_sys = tik_dec_emu = false;
@@ -2184,8 +2186,9 @@ u32 HomeMoreMenu(char* current_path) {
         bool seed_sys = false;
         bool seed_emu = false;
         if (BuildSeedInfo(NULL, false) == 0) {
-            ShowString("Building " SEEDINFO_NAME "...");
+            ShowString("Building " SEEDINFO_NAME " (SysNAND)...");
             seed_sys = (BuildSeedInfo("1:", false) == 0);
+            ShowString("Building " SEEDINFO_NAME " (EmuNAND)...");
             seed_emu = (BuildSeedInfo("4:", false) == 0);
             if (!seed_sys || BuildSeedInfo(NULL, true) != 0)
                 seed_sys = seed_emu = false;

--- a/arm9/source/utils/gameutil.c
+++ b/arm9/source/utils/gameutil.c
@@ -3741,26 +3741,13 @@ u32 BuildTitleKeyInfo(const char* path, bool dec, bool dump) {
             return 1;
         }
     } else if (filetype & SYS_TICKDB) {
-        if (!InitImgFS(path_in))
-            return 1;
+        u32 num_entries = 0;
+        u8* title_ids = NULL;
 
-        u32 num_entries = GetNumTickets(PART_PATH);
-
-        if (!num_entries)
-        {
-            InitImgFS(NULL);
-            return 1;
-        }
-
-        u8* title_ids = (u8*) malloc(num_entries * 8);
-
-        if (!title_ids)
-        {
-            InitImgFS(NULL);
-            return 1;
-        }
-
-        if ((ListTicketTitleIDs(PART_PATH, title_ids, num_entries) != 0)) {
+        if (!InitImgFS(path_in) || 
+            !(num_entries = GetNumTickets(PART_PATH)) ||
+            !(title_ids = (u8*) malloc(num_entries * 8)) ||
+            (ListTicketTitleIDs(PART_PATH, title_ids, num_entries) != 0)) {
             free(title_ids);
             InitImgFS(NULL);
             return 1;


### PR DESCRIPTION
Because `ticket.db` is not mounted soon enough, any time you try to build (dec/enc)TitleKeys.bin from a ticket database, it will fail. I've rearranged the code to resolve this.