### PR TITLE
changes to add created/modified/last accessed date

### DIFF
--- a/arm9/source/fatfs/ff.h
+++ b/arm9/source/fatfs/ff.h
@@ -246,8 +246,8 @@ typedef struct {
 
 typedef struct {
 	FSIZE_t	fsize;			/* File size */
-	WORD	fdate;			/* Modified date */
-	WORD	ftime;			/* Modified time */
+	WORD	mod_fdate;			/* Modified date */
+	WORD	mod_ftime;			/* Modified time */
 	BYTE	fattrib;		/* File attribute */
 #if FF_USE_LFN
 	TCHAR	altname[FF_SFN_BUF + 1];/* Altenative file name */
@@ -255,6 +255,9 @@ typedef struct {
 #else
 	TCHAR	fname[12 + 1];	/* File name */
 #endif
+	WORD    crt_fdate;  			/* Creation date */
+	WORD    crt_ftime;			/* Creation time */
+	WORD    lac_fdate;          /* Last access date */ 
 } FILINFO;
 
 

--- a/arm9/source/filesys/vff.c
+++ b/arm9/source/filesys/vff.c
@@ -84,8 +84,8 @@ FRESULT fvx_stat (const TCHAR* path, FILINFO* fno) {
         if (!GetVirtualFile(&vfile, path, FA_READ)) return FR_NO_PATH;
         if (fno) {
             fno->fsize = vfile.size;
-            fno->fdate = (1<<5)|(1<<0); // 1 for month / day
-            fno->ftime = 0;
+            fno->mod_fdate = fno->crt_fdate = fno->lac_fdate = (1<<5)|(1<<0); // 1 for month / day
+            fno->mod_ftime = fno->crt_ftime = 0;
             fno->fattrib = (vfile.flags & VFLAG_DIR) ? (AM_DIR|AM_VRT) : AM_VRT;
             // could be better...
             if (FF_USE_LFN != 0) GetVirtualFilename(fno->fname, &vfile, FF_MAX_LFN + 1);
@@ -137,7 +137,7 @@ FRESULT fvx_readdir (DIR* dp, FILINFO* fno) {
             VirtualFile vfile;
             if (ReadVirtualDir(&vfile, vdir)) {
                 fno->fsize = vfile.size;
-                fno->fdate = fno->ftime = 0;
+                fno->mod_fdate = fno->crt_fdate = fno->lac_fdate = (1<<5)|(1<<0); // 1 for month / day
                 fno->fattrib = (vfile.flags & VFLAG_DIR) ? (AM_DIR|AM_VRT) : AM_VRT;
                 GetVirtualFilename(fno->fname, &vfile, FF_MAX_LFN + 1);
             } else *(fno->fname) = 0;

--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -1024,7 +1024,7 @@ u32 CartRawDump(void) {
 u32 DirFileAttrMenu(const char* path, const char *name) {
     bool drv = (path[2] == '\0');
     bool vrt = (!drv); // will be checked below
-    char namestr[128], datestr[32], attrstr[128], sizestr[192];
+    char namestr[128], mod_datestr[32], crt_datestr[32], lac_datestr[32], attrstr[128], sizestr[192];
     FILINFO fno;
     u8 new_attrib;
 
@@ -1036,12 +1036,21 @@ u32 DirFileAttrMenu(const char* path, const char *name) {
         if (fvx_stat(path, &fno) != FR_OK) return 1;
         vrt = (fno.fattrib & AM_VRT);
         new_attrib = fno.fattrib;
-        snprintf(datestr, 32, "%s: %04d-%02d-%02d %02d:%02d:%02d\n",
-            (fno.fattrib & AM_DIR) ? "created" : "modified",
-            1980 + ((fno.fdate >> 9) & 0x7F), (fno.fdate >> 5) & 0xF, fno.fdate & 0x1F,
-            (fno.ftime >> 11) & 0x1F, (fno.ftime >> 5) & 0x3F, (fno.ftime & 0x1F) << 1);
+        snprintf(mod_datestr, 32, "%s: %04d-%02d-%02d %02d:%02d:%02d\n",
+            "modified",
+            1980 + ((fno.mod_fdate >> 9) & 0x7F), (fno.mod_fdate >> 5) & 0xF, fno.mod_fdate & 0x1F,
+            (fno.mod_ftime >> 11) & 0x1F, (fno.mod_ftime >> 5) & 0x3F, (fno.mod_ftime & 0x1F) << 1);
+		snprintf(crt_datestr, 32, "%s: %04d-%02d-%02d %02d:%02d:%02d\n",
+            "created ",
+            1980 + ((fno.crt_fdate >> 9) & 0x7F), (fno.crt_fdate >> 5) & 0xF, fno.crt_fdate & 0x1F,
+            (fno.crt_ftime >> 11) & 0x1F, (fno.crt_ftime >> 5) & 0x3F, (fno.crt_ftime & 0x1F) << 1);
+		snprintf(lac_datestr, 32, "%s: %04d-%02d-%02d\n",
+            "accessed",
+            1980 + ((fno.lac_fdate >> 9) & 0x7F), (fno.lac_fdate >> 5) & 0xF, fno.lac_fdate & 0x1F);
     } else {
-        *datestr = '\0';
+        *mod_datestr = '\0';
+		*crt_datestr = '\0';
+		*lac_datestr = '\0';
         *attrstr = '\0';
         new_attrib = 0;
     }
@@ -1095,11 +1104,13 @@ u32 DirFileAttrMenu(const char* path, const char *name) {
 
         ShowString(
             "%s\n \n"   // name
-            "%s"        // date (not for drives)
+            "%s"        // modified date (not for drives)
+			"%s"        // created date (not for drives)
+			"%s\n \n"        // accessed date (not for drives)
             "%s\n"      // size
             "%s \n"     // attr (not for drives)
             "%s\n",     // options
-            namestr, datestr, sizestr, attrstr,
+            namestr, mod_datestr, crt_datestr, lac_datestr, sizestr, attrstr,
             (drv || vrt || (new_attrib == fno.fattrib)) ? "(<A> to continue)" : "(<A> to apply, <B> to cancel)"
         );
 


### PR DESCRIPTION
**I know this isn't exactly a good idea.**

As mentioned in issue #758, GodMode9 currently does not show file creation date. It shows whatever FatFs returns in `FILINFO`, which is creation date (in case of directories) and modification date (in case of files). 

According to [this document](https://cscie92.dce.harvard.edu/spring2021/slides/FAT32%20File%20Structure.pdf), it's possible to get:
- Creation Date + Time
- Modification Date + Time
- Last Accessed Date (no Time here)

This may not seem like a good idea at first, but I got it working by modifying FatFs a tiny bit.
I made sure not to mess with anything that isn't related. I also made sure the dates are correct for drives and virtual drives, keeping the date that was previously intended to be shown.

`FILINFO` only stored one Date and Time, so the first thing I did was adding new fields to store the other Dates/Times.
Then, I made sure the Dates/Times were updated accordingly (for writes, file/dir creation, etc.).

This is what I got after that:
![grafik](https://user-images.githubusercontent.com/18742654/151353551-6986fbd9-0dac-4d86-b3dd-68ded8fe661c.png)

The data shown is identical to the data shown in the Windows Explorer "Properties" menu, so it is at the very least correct.
I have also tested the modified date, by creating a file, modifying it in the built in hex editor and saving it. The modified date/last access date is updated accordingly.

Overall it's a pretty minimal change. I understand that it may not be something you wish to add, but if it works, IMO, why not.

Let me know what you think.