### PR TITLE
Improve DSiWare save generation

### DIFF
--- a/arm9/source/game/nds.c
+++ b/arm9/source/game/nds.c
@@ -55,20 +55,24 @@ u32 BuildTwlSaveHeader(void* sav, u32 size) {
     u16 n_sct = 1;
     u16 sct_track = 1;
     u16 sct_heads = 1;
-    while (true) {
-        if (sct_heads < sct_track) {
-            u16 n_sct_next = sct_track * (sct_heads+1) * (sct_heads+1);
-            if (n_sct_next < n_sct_max) {
-                sct_heads++;
+    u16 n_sct_next = 0;
+    while (n_sct_next <= n_sct_max) {
+        n_sct_next = sct_track * (sct_heads + 1) * (sct_heads + 1);
+        if (n_sct_next <= n_sct_max) {
+            sct_heads++;
+            n_sct = n_sct_next;
+
+            sct_track++;
+            n_sct_next = sct_track * sct_heads * sct_heads;
+            if (n_sct_next <= n_sct_max) {
                 n_sct = n_sct_next;
-            } else break;
-        } else {
-            u16 n_sct_next = (sct_track+1) * sct_heads * sct_heads;
-            if (n_sct_next < n_sct_max) {
-                sct_track++;
-                n_sct = n_sct_next;
-            } else break;
+            }
         }
+    }
+    n_sct_next = (sct_track + 1) * sct_heads * sct_heads;
+    if (n_sct_next <= n_sct_max) {
+        sct_track++;
+        n_sct = n_sct_next;
     }
 
     // sectors per cluster (should be identical to Nintendo)


### PR DESCRIPTION
The sector/track/head count calculation for DSiWare saves was a bit off resulting in some DSiWare refusing to boot because the save 'didn't have enough room' or such. If you want to test, Dragon Quest Wars (EUR) is one game that was broken, theoretically any game with a 32 KiB save (or like half the other sizes) should be broken but most probably don't bother checking.

I've tested this calculation against all 25 sizes that TWiLight Menu++ has (it has [hardcoded template files](https://github.com/DS-Homebrew/TWiLightMenu/tree/b3ca0f376e499545ada022db4757cd8c407085fe/romsel_dsimenutheme/nitrofiles/DSiWareSaveHeaders) at the moment) and everything seems to generate correctly with this change.