### PR TITLE
Add Brazil to SysInfo serial number recognition.

### DIFF
--- a/arm9/source/utils/sysinfo.c
+++ b/arm9/source/utils/sysinfo.c
@@ -44,6 +44,7 @@ static const struct {
     { 'U', "United Kingdom" },
     { 'S', "Middle East" }, // "S" = Saudi Arabia?  Singapore?  (Southeast Asia included.)
     { 'A', "Australia" },
+    { 'B', "Brazil" },
 };
 
 // Structure of system information.


### PR DESCRIPTION
Today I learned that Brazil exists as a subregion of 3DS.

[Picture of a Brazilian 3DS](https://files.tecnoblog.net/wp-content/uploads/2011/05/nintendo-3ds-review-galeria-04.jpg)