### PR TITLE
Fix buffer overflow when encrypting/decrypting CIA files non-inplace

### DIFF
--- a/arm9/source/utils/gameutil.c
+++ b/arm9/source/utils/gameutil.c
@@ -1317,12 +1317,18 @@ u32 CryptCiaFile(const char* orig, const char* dest, u16 crypto) {
 
     // if not inplace: take over CIA metadata
     if (!inplace && (info.size_meta == CIA_META_SIZE)) {
-        CiaMeta* meta = (CiaMeta*) (void*) (cia + 1);
-        if ((fvx_qread(orig, meta, info.offset_meta, CIA_META_SIZE, NULL) != FR_OK) ||
-            (fvx_qwrite(dest, meta, info.offset_meta, CIA_META_SIZE, NULL) != FR_OK)) {
+        CiaMeta* meta = (CiaMeta*) malloc(sizeof(CiaMeta));
+        if (!meta) {
             free(cia);
             return 1;
         }
+        if ((fvx_qread(orig, meta, info.offset_meta, CIA_META_SIZE, NULL) != FR_OK) ||
+            (fvx_qwrite(dest, meta, info.offset_meta, CIA_META_SIZE, NULL) != FR_OK)) {
+            free(cia);
+            free(meta);
+            return 1;
+        }
+        free(meta);
     }
 
     // fix TMD hashes, write CIA stub to destination


### PR DESCRIPTION
The issue would occur when encrypting or decrypting CIA files (**that have a meta region**) to `0:/gm9/out`. It is caused by passing a pointer to a buffer that is not large enough to hold the CIA meta section. The solution is to allocate a separate buffer, as has been done in other places where the meta section is copied.