### PR TITLE
Fix compilation warnings on dkA r60

### DIFF
--- a/arm9/source/filesys/filetype.c
+++ b/arm9/source/filesys/filetype.c
@@ -163,7 +163,7 @@ u64 IdentifyFileType(const char* path) {
         return BIN_CIFNSH;
     } else if (ValidateText((char*) data, (fsize > 0x200) ? 0x200 : fsize)) {
         u64 type = 0;
-        if ((fsize < SCRIPT_MAX_SIZE) && (strncasecmp(ext, SCRIPT_EXT, strnlen(SCRIPT_EXT, 16) + 1) == 0))
+        if ((fsize < SCRIPT_MAX_SIZE) && (strcasecmp(ext, SCRIPT_EXT) == 0))
             type |= TXT_SCRIPT; // should be a script (which is also generic text)
         if (fsize < STD_BUFFER_SIZE) type |= TXT_GENERIC;
         return type;

--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -125,8 +125,8 @@ u32 BootFirmHandler(const char* bootpath, bool verbose, bool delete) {
 u32 SplashInit(const char* modestr) {
     u64 splash_size;
     u8* splash = FindVTarFileInfo(VRAM0_SPLASH_PNG, &splash_size);
-    const char* namestr = FLAVOR " " VERSION;
-    const char* loadstr = "booting...";
+    const char *namestr = FLAVOR " " VERSION;
+    const char *loadstr = "booting...";
     const u32 pos_xb = 10;
     const u32 pos_yb = 10;
     const u32 pos_xu = SCREEN_WIDTH_BOT - 10 - GetDrawStringWidth(loadstr);
@@ -149,7 +149,7 @@ u32 SplashInit(const char* modestr) {
         SCREEN_HEIGHT - 10 - GetDrawStringHeight(modestr), COLOR_STD_FONT, COLOR_TRANSPARENT, "%s", modestr);
 
     DrawStringF(BOT_SCREEN, pos_xb, pos_yb, COLOR_STD_FONT, COLOR_STD_BG, "%s\n%*.*s\n%s\n \n \n%s\n%s\n \n%s\n%s",
-        namestr, strnlen(namestr, 64), strnlen(namestr, 64),
+        namestr, strlen(namestr), strlen(namestr),
         "--------------------------------", "https://github.com/d0k3/GodMode9",
         "Releases:", "https://github.com/d0k3/GodMode9/releases/", // this won't fit with a 8px width font
         "Hourlies:", "https://d0k3.secretalgorithm.com/");

--- a/arm9/source/utils/scripting.c
+++ b/arm9/source/utils/scripting.c
@@ -1631,7 +1631,7 @@ void MemTextView(const char* text, u32 len, char* line0, int off_disp, int lno, 
     u32 x_txt = (TV_LNOS >= 0) ? TV_HPAD + ((TV_LNOS+1)*FONT_WIDTH_EXT) : TV_HPAD;
     u32 x_lno = TV_HPAD;
     u32 p_al = 0;
-    u32 p_ar = TV_LLEN_DISP - strnlen(ar_str, 16);
+    u32 p_ar = TV_LLEN_DISP - strlen(ar_str);
     u32 x_al = x_txt + (p_al * FONT_WIDTH_EXT);
     u32 x_ar = x_txt + (p_ar * FONT_WIDTH_EXT);
 
@@ -1661,8 +1661,8 @@ void MemTextView(const char* text, u32 len, char* line0, int off_disp, int lno, 
         snprintf(txtstr, sizeof(txtstr), "%-*.*s", (int) TV_LLEN_DISP, (int) TV_LLEN_DISP, "");
         if (ncpy) memcpy(txtstr, ptr + off_disp, ncpy);
         for (char* d = txtstr; *d; d++) if (*d < ' ') *d = ' ';
-        if (al) memcpy(txtstr + p_al, al_str, strnlen(al_str, 16));
-        if (ar) memcpy(txtstr + p_ar, ar_str, strnlen(ar_str, 16));
+        if (al) memcpy(txtstr + p_al, al_str, strlen(al_str));
+        if (ar) memcpy(txtstr + p_ar, ar_str, strlen(ar_str));
 
         // draw line number & text
         DrawString(TOP_SCREEN, txtstr, x_txt, y, color_text, COLOR_STD_BG);


### PR DESCRIPTION
Mostly just switched out the bound strn* functions for their unbound variants when the string is a known constant