### PR TITLE
Embed the VRAM tar data in the ARM9 executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,9 @@ $(VRAM_TAR): $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA) $(VRAM_SCRIPTS)
 	@echo "Building $@"
 	@$(MAKE) --no-print-directory -C $(@D)
 
-firm: $(ELF) $(VRAM_TAR)
+arm9/arm9.elf: $(VRAM_TAR)
+
+firm: $(ELF)
 	@mkdir -p $(call dirname,"$(FIRM)") $(call dirname,"$(FIRMD)")
 	@echo "[FLAVOR] $(FLAVOR)"
 	@echo "[VERSION] $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ export RELDIR := release
 export COMMON_DIR := ../common
 
 # Definitions for initial RAM disk
-VRAM_OUT    := $(OUTDIR)/vram0.tar
+VRAM_TAR    := $(OUTDIR)/vram0.tar
 VRAM_DATA   := data
-VRAM_FLAGS  := --make-new --path-limit 99 --size-limit 228864
+VRAM_FLAGS  := --make-new --path-limit 99 --size-limit 262144
 ifeq ($(NTRBOOT),1)
 	VRAM_SCRIPTS := resources/gm9/scripts
 endif
@@ -44,14 +44,14 @@ export CFLAGS  := -DDBUILTS="\"$(DBUILTS)\"" -DDBUILTL="\"$(DBUILTL)\"" -DVERSIO
 export LDFLAGS := -Tlink.ld -nostartfiles -Wl,--gc-sections,-z,max-page-size=4096
 ELF := arm9/arm9.elf arm11/arm11.elf
 
-.PHONY: all firm vram0 elf release clean
+.PHONY: all firm $(VRAM_TAR) elf release clean
 all: firm
 
 clean:
 	@set -e; for elf in $(ELF); do \
 	    $(MAKE) --no-print-directory -C $$(dirname $$elf) clean; \
 	done
-	@rm -rf $(OUTDIR) $(RELDIR) $(FIRM) $(FIRMD) $(VRAM_OUT)
+	@rm -rf $(OUTDIR) $(RELDIR) $(FIRM) $(FIRMD) $(VRAM_TAR)
 
 unmarked_readme: .FORCE
 	@$(PY3) utils/unmark.py -f README.md data/README_internal.md
@@ -80,24 +80,25 @@ release: clean unmarked_readme
 
 	@-7za a $(RELDIR)/$(FLAVOR)-$(VERSION)-$(DBUILTS).zip ./$(RELDIR)/*
 
-vram0:
-	@mkdir -p "$(OUTDIR)"
-	@echo "Creating $(VRAM_OUT)"
-	@$(PY3) utils/add2tar.py $(VRAM_FLAGS) $(VRAM_OUT) $(shell ls -d $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA)/* $(VRAM_SCRIPTS))
+$(VRAM_TAR): $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA) $(VRAM_SCRIPTS)
+	@mkdir -p "$(@D)"
+	@echo "Creating $@"
+	@$(PY3) utils/add2tar.py $(VRAM_FLAGS) $(VRAM_TAR) $(shell find $^ -type f)
 
 %.elf: .FORCE
 	@echo "Building $@"
 	@$(MAKE) --no-print-directory -C $(@D)
 
-firm: $(ELF) vram0
-	@test `wc -c <$(VRAM_OUT)` -le 228864
+firm: $(ELF) $(VRAM_TAR)
 	@mkdir -p $(call dirname,"$(FIRM)") $(call dirname,"$(FIRMD)")
 	@echo "[FLAVOR] $(FLAVOR)"
 	@echo "[VERSION] $(VERSION)"
 	@echo "[BUILD] $(DBUILTL)"
 	@echo "[FIRM] $(FIRM)"
-	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -A 0x80C0000 -D $(ELF) $(VRAM_OUT) -C NDMA XDMA memcpy
+	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -D $(ELF) -C NDMA XDMA
 	@echo "[FIRM] $(FIRMD)"
-	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -A 0x80C0000 -D $(ELF) $(VRAM_OUT)  -C NDMA XDMA memcpy
+	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -D $(ELF) -C NDMA XDMA
+
+vram0: $(VRAM_TAR) .FORCE # legacy target name
 
 .FORCE:

--- a/arm9/source/system/vram0.h
+++ b/arm9/source/system/vram0.h
@@ -19,10 +19,10 @@
 
 
 extern const char vram_data[];
-extern const u32 vram_data_size;
+extern const char vram_data_end[];
 
 #define VRAM0_OFFSET    (uintptr_t)(vram_data)
-#define VRAM0_LIMIT     vram_data_size
+#define VRAM0_LIMIT     (uintptr_t)(vram_data_end - vram_data)
 
 #define TARDATA         ((void*) VRAM0_OFFSET)
 #define TARDATA_(off)   ((void*) (u32) (VRAM0_OFFSET + (off)))

--- a/arm9/source/system/vram0.h
+++ b/arm9/source/system/vram0.h
@@ -18,13 +18,15 @@
 #define VRAM0_EASTER_BIN       "easter.bin"
 
 
-#define VRAM0_OFFSET    0x080C0000
-#define VRAM0_LIMIT     0x00040000
+extern const char vram_data[];
+extern const u32 vram_data_size;
+
+#define VRAM0_OFFSET    (uintptr_t)(vram_data)
+#define VRAM0_LIMIT     vram_data_size
 
 #define TARDATA         ((void*) VRAM0_OFFSET)
 #define TARDATA_(off)   ((void*) (u32) (VRAM0_OFFSET + (off)))
 #define TARDATA_END     TARDATA_(VRAM0_LIMIT)
-
 
 #define CheckVram0Tar() \
     (ValidateTarHeader(TARDATA, TARDATA_END) == 0)

--- a/arm9/source/system/vram_data.s
+++ b/arm9/source/system/vram_data.s
@@ -1,0 +1,12 @@
+.section .rodata.vram_data
+
+.align 2
+.global vram_data
+vram_data:
+	.incbin "../output/vram0.tar"
+vram_data_end:
+
+.align 2
+.global vram_data_size
+vram_data_size:
+	.word vram_data_end - vram_data

--- a/arm9/source/system/vram_data.s
+++ b/arm9/source/system/vram_data.s
@@ -4,9 +4,5 @@
 .global vram_data
 vram_data:
 	.incbin "../output/vram0.tar"
+.global vram_data_end
 vram_data_end:
-
-.align 2
-.global vram_data_size
-vram_data_size:
-	.word vram_data_end - vram_data


### PR DESCRIPTION
As a follow up to some of my comments on #816, this PR removes the extra FIRM section that was used as the "VRAM drive" (huge misnomer for a while but whatever, my bad) and instead embeds it as part of the ARM9 section, compiled as part of the `arm9.elf` binary.