### PR TITLE
arm9/arm11 Makefile: Fix building with spaces in path

### DIFF
--- a/arm11/Makefile
+++ b/arm11/Makefile
@@ -1,6 +1,6 @@
 PROCESSOR := ARM11
 
-TARGET := $(shell basename $(CURDIR))
+TARGET := $(shell basename "$(CURDIR)")
 
 SOURCE := source
 BUILD  := build

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -1,6 +1,6 @@
 PROCESSOR := ARM9
 
-TARGET := $(shell basename $(CURDIR))
+TARGET := $(shell basename "$(CURDIR)")
 
 SOURCE := source
 BUILD  := build


### PR DESCRIPTION
This quotes $(CURDIR) which fixes an issue with building GM9 in a path with spaces, which Windows users are likely to have.