### PR TITLE
Split GM9 across two sections in memory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ firm: $(ELF) $(BINS)
 	@echo "[BUILD] $(DBUILTL)"
 	@echo "[FIRM] $(FIRM)"
 	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -D $(BINS) arm11/arm11.elf \
-		-A 0x08000000 0x080a0000 -C NDMA NDMA XDMA -n 0x08000040
+		-A 0x08000040 0x080a0000 -C NDMA NDMA XDMA -n 0x08000080
 	@echo "[FIRM] $(FIRMD)"
 	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -D $(BINS) arm11/arm11.elf \
-		-A 0x08000000 0x080a0000 -C NDMA NDMA XDMA -n 0x08000040
+		-A 0x08000040 0x080a0000 -C NDMA NDMA XDMA -n 0x08000080
 
 vram0: $(VRAM_TAR) .FORCE # legacy target name
 

--- a/Makefile
+++ b/Makefile
@@ -91,15 +91,25 @@ $(VRAM_TAR): $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA) $(VRAM_SCRIPTS)
 
 arm9/arm9.elf: $(VRAM_TAR)
 
-firm: $(ELF)
+$(OUTDIR)/AHBWRAM.bin: $(ELF)
+	@$(OBJCOPY) -O binary arm9/arm9.elf --only-section=AHBWRAM $@
+
+$(OUTDIR)/AHBWRAM2.bin: $(ELF)
+	@$(OBJCOPY) -O binary arm9/arm9.elf --only-section=AHBWRAM2 $@
+
+BINS := $(OUTDIR)/AHBWRAM.bin $(OUTDIR)/AHBWRAM2.bin
+
+firm: $(ELF) $(BINS)
 	@mkdir -p $(call dirname,"$(FIRM)") $(call dirname,"$(FIRMD)")
 	@echo "[FLAVOR] $(FLAVOR)"
 	@echo "[VERSION] $(VERSION)"
 	@echo "[BUILD] $(DBUILTL)"
 	@echo "[FIRM] $(FIRM)"
-	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -D $(ELF) -C NDMA XDMA
+	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -D $(BINS) arm11/arm11.elf \
+		-A 0x08000000 0x080a0000 -C NDMA NDMA XDMA -n 0x08000040
 	@echo "[FIRM] $(FIRMD)"
-	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -D $(ELF) -C NDMA XDMA
+	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -D $(BINS) arm11/arm11.elf \
+		-A 0x08000000 0x080a0000 -C NDMA NDMA XDMA -n 0x08000040
 
 vram0: $(VRAM_TAR) .FORCE # legacy target name
 

--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,13 @@ $(VRAM_TAR): $(SPLASH) $(OVERRIDE_FONT) $(VRAM_DATA) $(VRAM_SCRIPTS)
 
 arm9/arm9.elf: $(VRAM_TAR)
 
-$(OUTDIR)/AHBWRAM.bin: $(ELF)
-	@$(OBJCOPY) -O binary arm9/arm9.elf --only-section=AHBWRAM $@
+$(OUTDIR)/AHBWRAM_LO.elf: $(ELF)
+	@$(OBJCOPY) arm9/arm9.elf -j AHBWRAM_LO $@
 
-$(OUTDIR)/AHBWRAM2.bin: $(ELF)
-	@$(OBJCOPY) -O binary arm9/arm9.elf --only-section=AHBWRAM2 $@
+$(OUTDIR)/AHBWRAM_HI.elf: $(ELF)
+	@$(OBJCOPY) arm9/arm9.elf -j AHBWRAM_HI $@
 
-BINS := $(OUTDIR)/AHBWRAM.bin $(OUTDIR)/AHBWRAM2.bin
+BINS := $(OUTDIR)/AHBWRAM_LO.elf $(OUTDIR)/AHBWRAM_HI.elf
 
 firm: $(ELF) $(BINS)
 	@mkdir -p $(call dirname,"$(FIRM)") $(call dirname,"$(FIRMD)")
@@ -106,10 +106,10 @@ firm: $(ELF) $(BINS)
 	@echo "[BUILD] $(DBUILTL)"
 	@echo "[FIRM] $(FIRM)"
 	@$(PY3) -m firmtool build $(FIRM) $(FTFLAGS) -g -D $(BINS) arm11/arm11.elf \
-		-A 0x08000040 0x080a0000 -C NDMA NDMA XDMA -n 0x08000080
+		-C NDMA NDMA XDMA
 	@echo "[FIRM] $(FIRMD)"
 	@$(PY3) -m firmtool build $(FIRMD) $(FTDFLAGS) -g -D $(BINS) arm11/arm11.elf \
-		-A 0x08000040 0x080a0000 -C NDMA NDMA XDMA -n 0x08000080
+		-C NDMA NDMA XDMA
 
 vram0: $(VRAM_TAR) .FORCE # legacy target name
 

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -10,8 +10,8 @@ INCDIRS := source source/common source/filesys source/crypto source/fatfs source
 INCLUDE := $(foreach dir,$(INCDIRS),-I"$(shell pwd)/$(dir)")
 
 ASFLAGS += $(SUBARCH) $(INCLUDE)
-CFLAGS  += $(SUBARCH) $(INCLUDE) -fno-builtin-memcpy -flto
-LDFLAGS += $(SUBARCH) -Wl,--use-blx,-Map,$(TARGET).map -flto
+CFLAGS  += $(SUBARCH) $(INCLUDE) -fno-builtin-memcpy
+LDFLAGS += $(SUBARCH) -Wl,--use-blx,-Map,$(TARGET).map
 
 include ../Makefile.common
 include ../Makefile.build

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -10,8 +10,9 @@ INCDIRS := source source/common source/filesys source/crypto source/fatfs source
 INCLUDE := $(foreach dir,$(INCDIRS),-I"$(shell pwd)/$(dir)")
 
 ASFLAGS += $(SUBARCH) $(INCLUDE)
-CFLAGS  += $(SUBARCH) $(INCLUDE) -fno-builtin-memcpy
-LDFLAGS += $(SUBARCH) -Wl,--use-blx,-Map,$(TARGET).map
+CFLAGS  += $(SUBARCH) $(INCLUDE) -fno-builtin-memcpy 
+LDFLAGS += $(SUBARCH) -Wl,--use-blx,-Map,$(TARGET).map \
+		   -Xlinker --no-warn-rwx-segments
 
 include ../Makefile.common
 include ../Makefile.build

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -4,15 +4,15 @@ ENTRY(_start)
 
 MEMORY
 {
-    AHBWRAM (RWX) : ORIGIN = 0x08000040, LENGTH = 512K - 64
-    AHBWRAM2 (RWX) : ORIGIN = 0x080a0000, LENGTH = 384K
+    AHBWRAM_LO (RWX) : ORIGIN = 0x08000040, LENGTH = 512K - 64
+    AHBWRAM_HI (RWX) : ORIGIN = 0x080a0000, LENGTH = 386K
 }
 
 SECTIONS
 {
     /* this must come *first* so it picks up lua */
-    AHBWRAM2 : ALIGN(4) {
-        build/lua*(.text*);
+    AHBWRAM_HI : ALIGN(4) {
+        *build/lua*(.text*);
 
         . = ALIGN(4);
         *(.rodata*);
@@ -27,12 +27,11 @@ SECTIONS
         __bss_end = .;
 
         __end__ = .;
-    } >AHBWRAM2
-
+    } >AHBWRAM_HI
 
 
     __vectors_lma = 0x08000000;
-    AHBWRAM : ALIGN(4) {
+    AHBWRAM_LO : ALIGN(4) {
         /* this needs to be absolute otherwise GM9 won't boot */
         __vectors_vma = ABSOLUTE(.);
         KEEP(*(.vectors));
@@ -40,18 +39,15 @@ SECTIONS
         __vectors_len = . - __vectors_vma;
         . = . + 0x10;
 
-
-
         . = ALIGN(4);
-        __text_s = .;
         *(.text.start);
         *(.text*);
-        __text_e = .;
 
         /* .ARM.exidx (needed for lua) */
         . = ALIGN(4);
         __exidx_start = .;
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
         __exidx_end = .;
-    } >AHBWRAM
+    } >AHBWRAM_LO
+
 }

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -19,13 +19,13 @@ SECTIONS
     } >AHBWRAM_HI
 
 
-    __vectors_lma = 0x08000000;
+    __vectors_vma = 0x08000000;
     AHBWRAM_LO : ALIGN(4) {
         /* this needs to be absolute otherwise GM9 won't boot */
-        __vectors_vma = ABSOLUTE(.);
+        __vectors_lma = ABSOLUTE(.);
         KEEP(*(.vectors));
         . = ALIGN(4);
-        __vectors_len = . - __vectors_vma;
+        __vectors_len = . - __vectors_lma;
 
         . = ALIGN(4);
         *(.text.start);

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -4,44 +4,53 @@ ENTRY(_start)
 
 MEMORY
 {
-    VECTORS (RX) : ORIGIN = 0x08000000, LENGTH = 64
-    AHBWRAM (RWX) : ORIGIN = 0x08000040, LENGTH = 512K - 64
+    AHBWRAM (RWX) : ORIGIN = 0x08000000, LENGTH = 512K
+    AHBWRAM2 (RWX) : ORIGIN = 0x080a0000, LENGTH = 384K
 }
 
 SECTIONS
 {
-    .vectors : ALIGN(4) {
-        __vectors_lma = LOADADDR(.vectors);
+    /* this must come *first* so it picks up lua */
+    AHBWRAM2 : ALIGN(4) {
+        build/lua*(.text*);
+
+        . = ALIGN(4);
+        *(.rodata*);
+
+        /* .data */
+        . = ALIGN(4);
+        *(.data*);
+
+        . = ALIGN(4);
+        __bss_start = .;
+        *(.bss*);
+        __bss_end = .;
+
+        __end__ = .;
+    } >AHBWRAM2
+
+
+    AHBWRAM : ALIGN(4) {
+        __vectors_lma = .;
+        /* this needs to be absolute otherwise GM9 won't boot */
         __vectors_vma = ABSOLUTE(.);
         KEEP(*(.vectors));
         . = ALIGN(4);
-        __vectors_len = ABSOLUTE(.) - __vectors_vma;
-    } >VECTORS AT>AHBWRAM
+        __vectors_len = . - __vectors_vma;
+        . = . + 0x10;
 
-    .text : ALIGN(4) {
-        __text_s = ABSOLUTE(.);
+
+
+        . = ALIGN(4);
+        __text_s = .;
         *(.text.start);
         *(.text*);
-        . = ALIGN(4);
-        __text_e = ABSOLUTE(.);
-    } >AHBWRAM
+        __text_e = .;
 
-    .rodata : ALIGN(4) {
-        *(.rodata*);
+        /* .ARM.exidx (needed for lua) */
         . = ALIGN(4);
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
     } >AHBWRAM
-
-    .data : ALIGN(4) {
-        *(.data*);
-        . = ALIGN(4);
-    } >AHBWRAM
-
-    .bss : ALIGN(4) {
-        __bss_start = .;
-        *(.bss*);
-        . = ALIGN(4);
-        __bss_end = .;
-    } >AHBWRAM
-
-    __end__ = ABSOLUTE(.);
 }

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -37,7 +37,6 @@ SECTIONS
         KEEP(*(.vectors));
         . = ALIGN(4);
         __vectors_len = . - __vectors_vma;
-        . = . + 0x10;
 
         . = ALIGN(4);
         *(.text.start);

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -13,20 +13,9 @@ SECTIONS
     /* this must come *first* so it picks up lua */
     AHBWRAM_HI : ALIGN(4) {
         *build/lua*(.text*);
+        libm*(.text*);
+		*(.rodata.vram_data);
 
-        . = ALIGN(4);
-        *(.rodata*);
-
-        /* .data */
-        . = ALIGN(4);
-        *(.data*);
-
-        . = ALIGN(4);
-        __bss_start = .;
-        *(.bss*);
-        __bss_end = .;
-
-        __end__ = .;
     } >AHBWRAM_HI
 
 
@@ -47,6 +36,20 @@ SECTIONS
         __exidx_start = .;
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
         __exidx_end = .;
+
+        . = ALIGN(4);
+        *(.rodata*);
+
+        /* .data */
+        . = ALIGN(4);
+        *(.data*);
+
+        . = ALIGN(4);
+        __bss_start = .;
+        *(.bss*);
+        __bss_end = .;
+
+        __end__ = .;
     } >AHBWRAM_LO
 
 }

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -4,7 +4,7 @@ ENTRY(_start)
 
 MEMORY
 {
-    AHBWRAM (RWX) : ORIGIN = 0x08000000, LENGTH = 512K
+    AHBWRAM (RWX) : ORIGIN = 0x08000040, LENGTH = 512K - 64
     AHBWRAM2 (RWX) : ORIGIN = 0x080a0000, LENGTH = 384K
 }
 
@@ -30,8 +30,9 @@ SECTIONS
     } >AHBWRAM2
 
 
+
+    __vectors_lma = 0x08000000;
     AHBWRAM : ALIGN(4) {
-        __vectors_lma = .;
         /* this needs to be absolute otherwise GM9 won't boot */
         __vectors_vma = ABSOLUTE(.);
         KEEP(*(.vectors));

--- a/arm9/source/start.s
+++ b/arm9/source/start.s
@@ -83,7 +83,7 @@ _start:
     @ Install exception handlers
     ldr r0, =__vectors_lma
     ldr r1, =__vectors_len
-    ldr r2, =XRQ_Start
+    ldr r2, =__vectors_vma
     add r1, r0, r1
     .LXRQ_Install:
         cmp r0, r1

--- a/arm9/source/system/xrq.c
+++ b/arm9/source/system/xrq.c
@@ -18,7 +18,6 @@
 
 #define PC_DUMPRAD (0x10)
 #define SP_DUMPLEN (0x80)
-extern u32 __text_s, __text_e;
 
 static bool sp_dumpable(u32 sp, u32 *sp_lower, u32 *sp_upper)
 {
@@ -31,7 +30,7 @@ static bool sp_dumpable(u32 sp, u32 *sp_lower, u32 *sp_upper)
 
 static bool pc_dumpable(u32 pc, u32 *pc_lower, u32 *pc_upper)
 {
-    u32 code_start = (u32)(&__text_s), code_end = (u32)(&__text_e);
+    u32 code_start = __A9RAM0_ADDR, code_end = __A9RAM0_ADDR + __A9RAM0_LEN;
 
     if ((pc >= code_end) || (pc < code_start))
         return false;


### PR DESCRIPTION
This is needed to implement support for Lua. Lua is way to big to fit in a single contiguous section of memory without overwriting our copy of boot9 and boot11, so some clever linker manipulation was used to place things in the free space after it. LTO also had to be disabled as we won't be able to split `.text` later with it.

This uses the following memory map:

```
AHBWRAM: 0x08000040 - 0x08080000
    .vectors
    .text
    .rodata
    .data
    .bss
    .rodata
    .data
    .bss

AHBWRAM2: 0x080a0000 - 0x08100000
    .text (files in arm9/source/lua)
    .text (libm)
    .rodata.vram_data

```

This has been tested on actual hardware and seems to boot up and work fine.