### PR TITLE
Undefined behavior fix on ticket.c

### DIFF
--- a/arm9/source/game/ticket.c
+++ b/arm9/source/game/ticket.c
@@ -120,7 +120,7 @@ u32 BuildVariableFakeTicket(Ticket** ticket, u32* ticket_size, const u8* title_i
 }
 
 u32 BuildFakeTicket(Ticket* ticket, const u8* title_id) {
-    Ticket* tik;
+    Ticket* tik = NULL;
     u32 ticket_size = sizeof(TicketCommon);
     u32 res = BuildVariableFakeTicket(&tik, &ticket_size, title_id, TICKET_MAX_CONTENTS);
     if (res != 0) return res;


### PR DESCRIPTION
Stack garbage is always a luck of the draw
This was causing issues on non-LTO build.
LTO was just lucky.
One bad pointer to rule them all.