### PR TITLE
Fix crashing in script runner mode

### DIFF
--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -3061,6 +3061,7 @@ u32 GodMode(int entrypoint) {
 u32 ScriptRunner(int entrypoint) {
     // init font and show splash
     if (!SetFont(NULL, 0)) return GODMODE_EXIT_POWEROFF;
+    SetLanguage(NULL, 0);
     SplashInit("scriptrunner mode");
     u64 timer = timer_start();
 


### PR DESCRIPTION
Script runner mode was crashing due to the language data being left uninitialized so it was trying to print out null pointers.

This makes it always initialize to the fallback English. I could also make it initialize to GodMode9's active language, but as it currently doesn't use the active font in script runner mode I mirrored that for the language.