### PR TITLE
Fcram bug fix + some imps

### DIFF
--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -111,8 +111,10 @@ u32 BootFirmHandler(const char* bootpath, bool verbose, bool delete) {
         if (delete) PathDelete(bootpath);
         DeinitExtFS();
         DeinitSDCardFS();
+        ARM_WbDC();
         PXI_DoCMD(PXICMD_LEGACY_BOOT, NULL, 0);
         PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
+        ARM_DSB();
         BootFirm((FirmHeader*) firm, fixpath);
         while(1);
     }
@@ -2541,8 +2543,10 @@ u32 GodMode(int entrypoint) {
         if (IsBootableFirm(firm_in_mem, FIRM_MAX_SIZE)) {
             DeinitExtFS();
             DeinitSDCardFS();
+            ARM_WbDC();
             PXI_DoCMD(PXICMD_LEGACY_BOOT, NULL, 0);
             PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
+            ARM_DSB();
             BootFirm(firm_in_mem, "sdmc:/bootonce.firm");
         }
         for (u32 i = 0; i < sizeof(bootfirm_paths) / sizeof(char*); i++) {


### PR DESCRIPTION
Hi, it is me, here the first pr, it has some improvements like cleaning the screen before power off something little since I noticed on my old3ds remaining like a ghost writings after screen turned off. 
Also I fixed the fcram boot bug, and added some little "improvements", i dunno probably useless but that's what I used during my testing. Though it should work even with the bare fix in the other pr. 
Choose or improve what's you like or even make a new one if this seems overkill or useless. 
Thanks for the attention. 
See ya
