### PR TITLE
Fix fcram boot bug

### DIFF
--- a/arm9/source/godmode.c
+++ b/arm9/source/godmode.c
@@ -2539,6 +2539,9 @@ u32 GodMode(int entrypoint) {
     if (bootloader) {
         const char* bootfirm_paths[] = { BOOTFIRM_PATHS };
         if (IsBootableFirm(firm_in_mem, FIRM_MAX_SIZE)) {
+            DeinitExtFS();
+            DeinitSDCardFS();
+            PXI_DoCMD(PXICMD_LEGACY_BOOT, NULL, 0);
             PXI_Barrier(PXI_FIRMLAUNCH_BARRIER);
             BootFirm(firm_in_mem, "sdmc:/bootonce.firm");
         }


### PR DESCRIPTION
Fixed old bug that appeared regarding the fcram boot failing, so this is the bare fix instead, so seems the most important part was docmd legacy boot so it should work also on this, though I tested only the other one since now, I'm out.
Thanks for the attention have a good day everyone.
P. S i was forgetting both should fix issue 774. 