### PR TITLE
[Testers needed] Increased CTRCARD clock from 4.18 to 13.4 MHz on ROM reads.

### DIFF
--- a/arm9/source/gamecart/command_ctr.c
+++ b/arm9/source/gamecart/command_ctr.c
@@ -27,7 +27,7 @@ void CTR_CmdReadData(u32 sector, u32 length, u32 blocks, void* buffer)
         (u32)((sector << 9) & 0xFFFFFFFF),
         0x00000000, 0x00000000
     };
-    CTR_SendCommand(read_cmd, length, blocks, 0x704822C, buffer);
+    CTR_SendCommand(read_cmd, length, blocks, 0x104822C, buffer); // Clock divider 5 (13.4 MHz). Same as Process9.
 }
 
 void CTR_CmdReadHeader(void* buffer)


### PR DESCRIPTION
This change significantly speeds up ROM reading by increasing the ROM read clock from 4.18 to 13.4 MHz. This is the same setting Process9 uses. I tested this with 26 different games and all verified successful with this change.

Example: Pokémon Ultra Moon previously verified in a bit more than 31 minutes. Now it verifies in ~19 minutes.

Steps to test:
1. Boot GodMode9.
2. Insert the 3DS game.
3. Open the gamecart drive.
4. Choose the topmost .3ds file (not the trimmed one).
5. NCSD options --> Verify file.

Report the result here. If your games do not verify successfully make sure to check with the latest GodMode9 release. Attached is a build with this change. 

[GodMode9-v2.1.1-43-g7b6b4785-20240919200412.zip](https://github.com/user-attachments/files/17063938/GodMode9-v2.1.1-43-g7b6b4785-20240919200412.zip)