### PR TITLE
Split up the ARM9 code and data sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.obj
 *.elf
 *.map
+*.dis
 
 # Precompiled Headers
 *.gch

--- a/Makefile.build
+++ b/Makefile.build
@@ -11,11 +11,12 @@ all: $(TARGET).elf
 
 .PHONY: clean
 clean:
-	@rm -rf $(BUILD) $(TARGET).elf $(TARGET).map
+	@rm -rf $(BUILD) $(TARGET).elf $(TARGET).dis $(TARGET).map
 
 $(TARGET).elf: $(OBJECTS) $(OBJECTS_COMMON)
 	@mkdir -p "$(@D)"
 	@$(CC) $(LDFLAGS) $^ -o $@
+	@$(OBJDUMP) -S $@ > $@.dis
 
 $(BUILD)/%.cmn.o: $(COMMON_DIR)/%.c
 	@mkdir -p "$(@D)"

--- a/Makefile.build
+++ b/Makefile.build
@@ -16,7 +16,7 @@ clean:
 $(TARGET).elf: $(OBJECTS) $(OBJECTS_COMMON)
 	@mkdir -p "$(@D)"
 	@$(CC) $(LDFLAGS) $^ -o $@
-	@$(OBJDUMP) -S $@ > $@.dis
+	@$(OBJDUMP) -S -h $@ > $@.dis
 
 $(BUILD)/%.cmn.o: $(COMMON_DIR)/%.c
 	@mkdir -p "$(@D)"

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,3 +1,4 @@
+export OBJDUMP	:=	arm-none-eabi-objdump
 
 dirname   = $(shell dirname $(1))
 

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -15,3 +15,9 @@ LDFLAGS += $(SUBARCH) -Wl,--use-blx,-Map,$(TARGET).map -flto
 
 include ../Makefile.common
 include ../Makefile.build
+
+arm9_data.elf: arm9.elf
+	arm-none-eabi-objcopy -O elf32-littlearm -j .rodata* -j .data* -j .bss* $< $@
+
+arm9_code.elf: arm9.elf
+	arm-none-eabi-objcopy -O elf32-littlearm -j .text* -j .vectors* $< $@

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -17,7 +17,7 @@ include ../Makefile.common
 include ../Makefile.build
 
 arm9_data.elf: arm9.elf
-	arm-none-eabi-objcopy -O elf32-littlearm -j .rodata* -j .data* -j .bss* $< $@
+	$(OBJCOPY) -O elf32-littlearm -j .rodata* -j .data* -j .bss* $< $@
 
 arm9_code.elf: arm9.elf
-	arm-none-eabi-objcopy -O elf32-littlearm -j .text* -j .vectors* $< $@
+	$(OBJCOPY) -O elf32-littlearm -j .text* -j .vectors* $< $@

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -5,7 +5,9 @@ ENTRY(_start)
 MEMORY
 {
     VECTORS (RX) : ORIGIN = 0x08000000, LENGTH = 64
-    AHBWRAM (RWX) : ORIGIN = 0x08000040, LENGTH = 512K - 64
+    CODEMEM (RX) : ORIGIN = 0x08000040, LENGTH = 512K - 64
+    BOOTROM (R)  : ORIGIN = 0x08080000, LENGTH = 128K /* BootROM mirrors, don't touch! */
+    DATAMEM (RW) : ORIGIN = 0x080A0000, LENGTH = 384K
 }
 
 SECTIONS
@@ -16,7 +18,7 @@ SECTIONS
         KEEP(*(.vectors));
         . = ALIGN(4);
         __vectors_len = ABSOLUTE(.) - __vectors_vma;
-    } >VECTORS AT>AHBWRAM
+    } >VECTORS AT>CODEMEM
 
     .text : ALIGN(4) {
         __text_s = ABSOLUTE(.);
@@ -24,24 +26,28 @@ SECTIONS
         *(.text*);
         . = ALIGN(4);
         __text_e = ABSOLUTE(.);
-    } >AHBWRAM
+    } >CODEMEM
 
     .rodata : ALIGN(4) {
         *(.rodata*);
         . = ALIGN(4);
-    } >AHBWRAM
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+        . = ALIGN(4);
+    } >DATAMEM
 
     .data : ALIGN(4) {
         *(.data*);
         . = ALIGN(4);
-    } >AHBWRAM
+    } >DATAMEM
 
-    .bss : ALIGN(4) {
+    .bss (NOLOAD) : ALIGN(4) {
         __bss_start = .;
         *(.bss*);
         . = ALIGN(4);
         __bss_end = .;
-    } >AHBWRAM
+    } >DATAMEM
 
     __end__ = ABSOLUTE(.);
 }


### PR DESCRIPTION
Split up the ARM9 code (.text, .vectors) and data (.rodata, .data, .bss) sections into their own ELFs. This allows us to use more ARM9 WRAM while leaving the 128k BootROM mirror intact.

It also removes the warning about having an RWX segment, though it also creates warnings about having empty segments (`arm-none-eabi-objcopy: arm9.elf: warning: empty loadable segment detected at vaddr=0x80a0000, is this intentional?`, still looking into the exact flags to get rid of it).