### PR TITLE
fix internalfs_make_dummy_file causing a data abort on failure

### DIFF
--- a/arm9/source/lua/gm9internalfs.c
+++ b/arm9/source/lua/gm9internalfs.c
@@ -467,7 +467,7 @@ static int internalfs_make_dummy_file(lua_State* L) {
     CheckWritePermissionsLuaError(L, path);
 
     if (!(FileCreateDummy(path, NULL, size))) {
-        return luaL_error(L, "FileCreateDummy failed on %s");
+        return luaL_error(L, "FileCreateDummy failed on %s", path);
     }
 
     return 0;


### PR DESCRIPTION
`internalfs_make_dummy_file` would cause a data abort on failure due to a missing variadic function parameter.