### PR TITLE
fix a few cases of improper varg usage in `luaL_error`

### DIFF
--- a/arm9/source/lua/gm9internalfs.c
+++ b/arm9/source/lua/gm9internalfs.c
@@ -122,7 +122,7 @@ static int internalfs_mkdir(lua_State* L) {
 
     FRESULT res = fvx_rmkdir(path);
     if (res != FR_OK) {
-        return luaL_error(L, "could not mkdir (%d)", path, res);
+        return luaL_error(L, "could not mkdir %s (%d)", path, res);
     }
 
     return 0;
@@ -467,7 +467,7 @@ static int internalfs_make_dummy_file(lua_State* L) {
     CheckWritePermissionsLuaError(L, path);
 
     if (!(FileCreateDummy(path, NULL, size))) {
-        return luaL_error(L, "FileCreateDummy failed on %s");
+        return luaL_error(L, "FileCreateDummy failed on %s", path);
     }
 
     return 0;

--- a/arm9/source/lua/gm9lua.h
+++ b/arm9/source/lua/gm9lua.h
@@ -35,7 +35,7 @@ static inline void CheckLuaArgCount(lua_State* L, int argcount, const char* cmd)
 static inline bool CheckLuaArgCountPlusExtra(lua_State* L, int argcount, const char* cmd) {
     int args = lua_gettop(L);
     if (args != argcount && args != argcount + 1) {
-        luaL_error(L, "bad number of arguments passed to '%s' (expected %d, got %d or %d)", cmd, argcount, args);
+        luaL_error(L, "bad number of arguments passed to '%s' (expected %d or %d, got %d)", cmd, argcount, argcount + 1, args);
     }
     return args == argcount + 1;
 }


### PR DESCRIPTION
There were a few cases of improper/missing variadic function parameters in calls to `luaL_error`, which would cause a data abort / invalid error message output on failure.