### PR TITLE
Lua documentation fixes

### DIFF
--- a/resources/lua-doc.md
+++ b/resources/lua-doc.md
@@ -570,7 +570,7 @@ Pattern can use `?` for search values, for example `nand_??.bin` will check to s
 
 #### fs.find_all
 
-* `string fs.find_all(string dir, string pattern[, table opts {bool recursive}])`
+* `array fs.find_all(string dir, string pattern[, table opts {bool recursive}])`
 
 Search for all files that match a pattern.
 * **Arguments**
@@ -578,6 +578,7 @@ Search for all files that match a pattern.
     * `pattern` - Filename pattern
 	* `opts` (optional) - Option flags
 		* `recursive` - Remove directories recursively
+* **Returns:** table of found files
 * **Throws**
 	* `"could not open directory"` - failed to open directory
 

--- a/resources/lua-doc.md
+++ b/resources/lua-doc.md
@@ -251,7 +251,7 @@ Ask the user to input text.
 
 #### ui.ask_selection
 
-* `int ui.ask_selection(string prompt, array options)`
+* `int ui.ask_selection(string prompt, table options)`
 
 Ask the user to choose an option from a list. A maximum of 256 options are allowed.
 
@@ -437,7 +437,7 @@ Create a directory. This creates intermediate directories as required, so `fs.mk
 
 #### fs.stat
 
-* `array fs.stat(string path)`
+* `table fs.stat(string path)`
 
 Get information about a file or directory. The result is a stat table with these keys:
 
@@ -453,7 +453,7 @@ Get information about a file or directory. The result is a stat table with these
 
 #### fs.list_dir
 
-* `array fs.list_dir(string path)`
+* `table fs.list_dir(string path)`
 
 Get the contents of a directory. The result is a list of stat tables with these keys:
 * `name` (string)
@@ -474,7 +474,7 @@ Get the contents of a directory. The result is a list of stat tables with these 
 
 #### fs.stat_fs
 
-* `array fs.stat_fs(string path)`
+* `table fs.stat_fs(string path)`
 
 Get information about a filesystem.
 
@@ -490,7 +490,7 @@ Get information about a filesystem.
 
 #### fs.dir_info
 
-* `array fs.dir_info(string path)`
+* `table fs.dir_info(string path)`
 
 Get information about a directory.
 
@@ -570,7 +570,7 @@ Pattern can use `?` for search values, for example `nand_??.bin` will check to s
 
 #### fs.find_all
 
-* `array fs.find_all(string dir, string pattern[, table opts {bool recursive}])`
+* `table fs.find_all(string dir, string pattern[, table opts {bool recursive}])`
 
 Search for all files that match a pattern.
 * **Arguments**

--- a/resources/lua-doc.md
+++ b/resources/lua-doc.md
@@ -111,9 +111,9 @@ EMUID0 | sys.emu_id0 |  
 EMUBASE | sys.emu_base |  
 SERIAL | sys.serial |  
 REGION | sys.region |  
-SDSIZE | fs.stat_fs("0:/").total | int instead of string (use util.format_bytes to format it)
-SDFREE | fs.stat_fs("0:/").free | int instead of string (use util.format_bytes to format it)
-NANDSIZE | NANDSIZE | int instead of string (use util.format_bytes to format it)
+SDSIZE | fs.stat_fs("0:/").total | int instead of string (use ui.format_bytes to format it)
+SDFREE | fs.stat_fs("0:/").free | int instead of string (use ui.format_bytes to format it)
+NANDSIZE | NANDSIZE | int instead of string (use ui.format_bytes to format it)
 GM9OUT | GM9OUT |  
 CURRDIR | CURRDIR | nil instead of “(null)" if it can’t be found
 ONTYPE | CONSOLE_TYPE | “O3DS" or “N3DS"

--- a/resources/lua-doc.md
+++ b/resources/lua-doc.md
@@ -680,8 +680,6 @@ Calculate the hash of a file and compare it with a corresponding `.sha` file.
 > [!IMPORTANT]
 > This currently assumes SHA-256. In the future this may automatically use SHA-1 when appropriate, based on the `.sha` file size.
 
-TODO: add errors for fs.read_file here
-
 * **Argumens**
 	* `path` - File to hash
 * **Returns:** `true` if successful, `false` if failed, `nil` if `.sha` file could not be read


### PR DESCRIPTION
Fix a couple oopsies (incorrectly documented fs.find_all, remove unnecessary todo, consistently use the term table instead of both table and array, fix incorrect reference to util.format_bytes)