### PR TITLE
lua io: fix incorrect mode detection

### DIFF
--- a/data/luapackages/io.lua
+++ b/data/luapackages/io.lua
@@ -35,7 +35,7 @@ function file.new(filename, mode)
     end
     debugf("opening", filename, mode)
     of = setmetatable({_filename=filename, _mode=mode, _seek=0, _open=true, _readable=false, _writable=false, _append_only=false}, file)
-    if string.find(mode, "w") then
+    if string.find(mode, "w", 1, true) then
         debugf("opening", filename, "for writing")
         -- preemptively allow writing instead of having that prompt at file:write
         allowed = fs.allow(filename)
@@ -48,7 +48,7 @@ function file.new(filename, mode)
         of._size = 0
         of._readable = false
         of._writable = true
-    elseif string.find(mode, "r+") then
+    elseif string.find(mode, "r+", 1, true) then
         debugf("opening", filename, "for updating")
         allowed = fs.allow(filename)
         debugf("allowed:", allowed)
@@ -64,7 +64,7 @@ function file.new(filename, mode)
             of._stat = {}
             of._size = 0
         end
-    elseif string.find(mode, "a") then
+    elseif string.find(mode, "a", 1, true) then
         debugf("opening", filename, "for appending")
         allowed = fs.allow(filename)
         debugf("allowed:", allowed)
@@ -82,7 +82,7 @@ function file.new(filename, mode)
             of._stat = {}
             of._size = 0
         end
-        if string.find(mode, "+") then
+        if string.find(mode, "+", 1, true) then
             debugf("append update mode")
             of._readable = true
         else


### PR DESCRIPTION
string.find has pattern matching by default, so it was incorrectly reading "r+" when the mode was supposed to be "r". So this disables the pattern matching and does a plain substring search.