### PR TITLE
GM9 Lua: "draw" class

### DIFF
--- a/arm9/source/lua/gm9draw.c
+++ b/arm9/source/lua/gm9draw.c
@@ -1,0 +1,93 @@
+#ifndef NO_LUA
+
+#include "gm9draw.h"
+#include "common/ui.h"
+#include "common/colors.h"
+
+static int draw_pixel(lua_State *L) {
+    CheckLuaArgCount(L, 4, "draw.pixel");
+    u16* screen;
+    
+    int screenID = lua_tonumber(L, 1);
+    if (screenID == 1) {
+        screen = TOP_SCREEN;
+    }
+    else if (screenID == 2) {
+        screen = BOT_SCREEN;
+    }
+
+    int x = lua_tonumber(L, 2);
+    int y = lua_tonumber(L, 3);
+    u32 color = lua_tonumber(L, 4);
+
+    DrawPixel(screen, x, y, color);
+    return 0;
+}
+
+static int draw_box(lua_State *L) {
+    CheckLuaArgCount(L, 6, "draw.box");
+    u16* screen;
+    
+    int screenID = lua_tonumber(L, 1);
+    if (screenID == 1) {
+        screen = TOP_SCREEN;
+    }
+    else if (screenID == 2) {
+        screen = BOT_SCREEN;
+    }
+
+    int x = lua_tonumber(L, 2);
+    int y = lua_tonumber(L, 3);
+    u32 w = lua_tonumber(L, 4);
+    u32 h = lua_tonumber(L, 5);
+    u32 color = lua_tonumber(L, 6);
+
+    DrawRectangle(screen, x, y, w, h, color);
+    return 0;
+}
+
+static int draw_text(lua_State *L) {
+    CheckLuaArgCount(L, 6, "draw.text");
+    u16* screen;
+    
+    int screenID = lua_tonumber(L, 1);
+    if (screenID == 1) {
+        screen = TOP_SCREEN;
+    }
+    else if (screenID == 2) {
+        screen = BOT_SCREEN;
+    }
+
+    const char* stringToDraw = lua_tostring(L, 2);
+    int x = lua_tonumber(L, 3);
+    int y = lua_tonumber(L, 4);
+    u32 color = lua_tonumber(L, 5);
+
+    DrawString(screen, stringToDraw, x, y, color, COLOR_STD_BG);
+    return 0;
+}
+
+static int draw_rgb(lua_State *L) {
+    CheckLuaArgCount(L, 3, "draw.rgb");
+
+    u32 r = lua_tonumber(L, 1);
+    u32 g = lua_tonumber(L, 2);
+    u32 b = lua_tonumber(L, 3);
+
+    return (int)RGB(r,g,b);
+}
+
+static const luaL_Reg draw[] = {
+    {"pixel", draw_pixel},
+    {"box", draw_box},
+    {"text", draw_text},
+    {"rgb", draw_rgb},
+    {NULL, NULL}
+};
+
+int gm9lua_open_draw(lua_State* L) {
+    luaL_newlib(L, draw);
+    return 1;
+}
+
+#endif

--- a/arm9/source/lua/gm9draw.c
+++ b/arm9/source/lua/gm9draw.c
@@ -74,7 +74,8 @@ static int draw_rgb(lua_State *L) {
     u32 g = lua_tonumber(L, 2);
     u32 b = lua_tonumber(L, 3);
 
-    return (int)RGB(r,g,b);
+    lua_pushinteger(L, (int)RGB(r,g,b));
+    return 1;
 }
 
 static const luaL_Reg draw[] = {

--- a/arm9/source/lua/gm9draw.c
+++ b/arm9/source/lua/gm9draw.c
@@ -47,7 +47,7 @@ static int draw_box(lua_State *L) {
 }
 
 static int draw_text(lua_State *L) {
-    CheckLuaArgCount(L, 6, "draw.text");
+    CheckLuaArgCount(L, 5, "draw.text");
     u16* screen;
     
     int screenID = lua_tonumber(L, 1);

--- a/arm9/source/lua/gm9draw.h
+++ b/arm9/source/lua/gm9draw.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "gm9lua.h"
+
+#define GM9LUA_DRAWLIBNAME "draw"
+
+int gm9lua_open_draw(lua_State* L);

--- a/arm9/source/lua/gm9lua.c
+++ b/arm9/source/lua/gm9lua.c
@@ -14,6 +14,7 @@
 #include "gm9title.h"
 #include "gm9internalfs.h"
 #include "gm9internalsys.h"
+#include "gm9draw.h"
 
 #define DEBUGSP(x) ShowPrompt(false, (x))
 
@@ -104,6 +105,7 @@ static const luaL_Reg gm9lualibs[] = {
     {GM9LUA_OSLIBNAME, gm9lua_open_os},
     {GM9LUA_UILIBNAME, gm9lua_open_ui},
     {GM9LUA_TITLELIBNAME, gm9lua_open_title},
+    {GM9LUA_DRAWLIBNAME, gm9lua_open_draw},
 
     // gm9 custom internals (usually wrapped by a pure lua module)
     {GM9LUA_INTERNALFSLIBNAME, gm9lua_open_internalfs},

--- a/arm9/source/lua/gm9ui.c
+++ b/arm9/source/lua/gm9ui.c
@@ -110,6 +110,14 @@ static int ui_clear(lua_State* L) {
     return 0;
 }
 
+static int ui_clear_full(lua_State* L) {
+    CheckLuaArgCount(L, 0, "ui.clear_full");
+
+    ClearScreenF(true, true, COLOR_STD_BG);
+
+    return 0;
+}
+
 static int ui_show_png(lua_State* L) {
     CheckLuaArgCount(L, 1, "ui.show_png");
     const char* path = luaL_checkstring(L, 1);
@@ -334,6 +342,7 @@ static const luaL_Reg ui_lib[] = {
     {"ask_text", ui_ask_text},
     {"ask_selection", ui_ask_selection},
     {"clear", ui_clear},
+    {"clear_full", ui_clear_full},
     {"show_png", ui_show_png},
     {"show_text", ui_show_text},
     {"show_game_info", ui_show_game_info},


### PR DESCRIPTION
This is a draft PR that adds support for drawing pixels, boxes, and text on Lua scripts.

While Lua scripting has only benefited processing commands on GodMod9, I thought it would be crazy to extend it to have features useful for creating other things such as games and apps.

I may not know the scope of GodMode9's scripting, but I wanted to try something new, so this exists.

So, yep.

--------

Functions added:

- draw.pixel(screenNumber, x, y, color) = Draws a pixel at a specified point at whatever screen you choose.
- draw.box(screenNumber, x, y, width, height, color) = Draws a filled box at a specified point at whatever screen you choose.
- draw.text(screenNumber, text, x, y, color) = Draws text with the font that's being used at a specified point at whatever screen you choose.
- draw.rgb(red, green, blue) = Creates an RGB color that can be used for any of the draw functions. Use this once in a variable for consistency.

- ui.clear_full() = Clears all screens than just the screen that's being used for scripts.

(Will add more if more is added)