### PR TITLE
CI: Fix a couple of minor bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,12 @@ jobs:
     container: devkitpro/devkitarm
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup environment
+        run: git config --global safe.directory '*'
 
       - name: Fix apt sources
         run: |

--- a/.github/workflows/crowdin-commit.yml
+++ b/.github/workflows/crowdin-commit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install python3 python3-pip -y
+          apt-get install python3 python3-pip p7zip-full -y
           python3 -m pip install --upgrade pip setuptools --break-system-packages
           python3 -m pip install cryptography git+https://github.com/TuxSH/firmtool.git --break-system-packages
 


### PR DESCRIPTION
This fixes two minor bugs in the CI system. These did not cause any major issues, but probably still good to get them fixed.

- ci.yml: No version number was in the uploaded zip or displayed in app
- crowdin-commit.yml: It errored silently that p7zip wasn't installed (noticed by @MisterSheeple) 