### PR TITLE
Change order of issuers for DEV. Fixes #959

### DIFF
--- a/arm9/source/game/cia.c
+++ b/arm9/source/game/cia.c
@@ -61,7 +61,7 @@ u32 BuildCiaCert(u8* ciacert) {
     };
 
     static const char* const retail_issuers[] = {"Root-CA00000003", "Root-CA00000003-XS0000000c", "Root-CA00000003-CP0000000b"};
-    static const char* const dev_issuers[] = {"Root-CA00000004", "Root-CA00000004-XS00000009", "Root-CA00000004-CP0000000a"};
+    static const char* const dev_issuers[] = {"Root-CA00000004", "Root-CA00000004-CP0000000a", "Root-CA00000004-XS00000009"};
 
     size_t size = CIA_CERT_SIZE;
     if (BuildRawCertBundleFromCertDb(ciacert, &size, !IS_DEVKIT ? retail_issuers : dev_issuers, 3) ||


### PR DESCRIPTION
Change the order of issuers for dev CIA, fixes #959, an issue where CIA building from .app didn't work.

Building a CIA seems to pass okay with this change.
Tested on an 03ds with version 0.35.0.
Title: `1:/title/00040000/0ff40002/content/c905d5bc.app` (DevMenu)