### PR TITLE
Add detection for IS-RAY-DEBUGGER

### DIFF
--- a/arm9/source/utils/sysinfo.c
+++ b/arm9/source/utils/sysinfo.c
@@ -256,6 +256,8 @@ void GetSysInfo_SecureInfo(SysInfo* info, char nand_drive) {
                 strncpy(info->sub_model, "IS-CTR-BOX", countof("IS-CTR-BOX"));
             } else if ((first_digit == '9') && (second_digit == '1') && (info->int_model == MODEL_OLD_3DS_XL)) {
                 strncpy(info->sub_model, "IS-SPR-BOX", countof("IS-SPR-BOX"));
+            } else if ((first_digit == '9') && (second_digit == '0') && (info->int_model == MODEL_NEW_3DS)){
+                strncpy(info->sub_model, "IS-RAY-DEBUGGER", countof("IS-RAY-DEBUGGER"));
             } else if ((first_digit == '9') && (second_digit == '1') && (info->int_model == MODEL_NEW_3DS)) {
                 strncpy(info->sub_model, "IS-SNAKE-BOX", countof("IS-SNAKE-BOX"));
             } else {

--- a/arm9/source/utils/sysinfo.c
+++ b/arm9/source/utils/sysinfo.c
@@ -250,7 +250,6 @@ void GetSysInfo_SecureInfo(SysInfo* info, char nand_drive) {
     // Determine the sub-model from the first two digits of the digit part.
     if (first_digit && second_digit) {
         if (IS_DEVKIT) {
-            // missing: identification for IS-CLOSER-BOX (issue #276)
             if ((first_digit == '9') && (second_digit == '0') && (info->int_model == MODEL_OLD_3DS)) {
                 strncpy(info->sub_model, "Partner-CTR", countof("Partner-CTR"));
             } else if ((first_digit == '9') && (second_digit == '1') && (info->int_model == MODEL_OLD_3DS)) {


### PR DESCRIPTION
This adds detection for IS-RAY-DEBUGGER units, as well as removing the erroneous note about IS-CLOSER-BOX units. Closes #276 