### PR TITLE
Fix PXI I2C size decode

### DIFF
--- a/arm11/source/main.c
+++ b/arm11/source/main.c
@@ -157,7 +157,7 @@ void __attribute__((noreturn)) MainLoop(void)
 
 				devId = (args[0] & 0xff);
 				regAddr = (args[0] >> 8) & 0xFF;
-				size = (args[0] >> 16) % SHMEM_BUFFER_SIZE;
+				size = ((args[0] >> 16) & 0x7FFF) % SHMEM_BUFFER_SIZE;
 
 				if (args[0] & BIT(31)) {
 					pxiReply = I2C_writeRegBuf(devId, regAddr, sharedMem.dataBuffer.b, size);

--- a/arm9/source/system/i2c.c
+++ b/arm9/source/system/i2c.c
@@ -8,11 +8,14 @@
 bool I2C_readRegBuf(I2cDevice devId, u8 regAddr, u8 *out, u32 size)
 {
 	int ret;
-	u8 *const dataBuffer = ARM_GetSHMEM()->dataBuffer.b;
-	const u32 arg = devId | (regAddr << 8) | (size << 16);
 
 	if (size >= SHMEM_BUFFER_SIZE)
 		return false;
+	if (size > 0x7FFF)
+		return false;
+
+	u8 *const dataBuffer = ARM_GetSHMEM()->dataBuffer.b;
+	const u32 arg = devId | (regAddr << 8) | (size << 16);
 
 	ret = PXI_DoCMD(PXICMD_I2C_OP, &arg, 1);
 	ARM_InvDC_Range(dataBuffer, size);
@@ -24,11 +27,14 @@ bool I2C_readRegBuf(I2cDevice devId, u8 regAddr, u8 *out, u32 size)
 bool I2C_writeRegBuf(I2cDevice devId, u8 regAddr, const u8 *in, u32 size)
 {
 	int ret;
-	u8 *const dataBuffer = ARM_GetSHMEM()->dataBuffer.b;
-	const u32 arg = devId | (regAddr << 8) | (size << 16) | BIT(31);
 
 	if (size >= SHMEM_BUFFER_SIZE)
 		return false;
+	if (size > 0x7FFF)
+		return false;
+
+	u8 *const dataBuffer = ARM_GetSHMEM()->dataBuffer.b;
+	const u32 arg = devId | (regAddr << 8) | (size << 16) | BIT(31);
 
 	memcpy(dataBuffer, in, size);
 	ARM_WbDC_Range(dataBuffer, size);

--- a/arm9/source/system/i2c.c
+++ b/arm9/source/system/i2c.c
@@ -9,9 +9,8 @@ bool I2C_readRegBuf(I2cDevice devId, u8 regAddr, u8 *out, u32 size)
 {
 	int ret;
 
-	if (size >= SHMEM_BUFFER_SIZE)
-		return false;
-	if (size > 0x7FFF)
+	_Static_assert(SHMEM_BUFFER_SIZE < BIT(15));
+	if (size >= BIT(15))
 		return false;
 
 	u8 *const dataBuffer = ARM_GetSHMEM()->dataBuffer.b;
@@ -28,9 +27,8 @@ bool I2C_writeRegBuf(I2cDevice devId, u8 regAddr, const u8 *in, u32 size)
 {
 	int ret;
 
-	if (size >= SHMEM_BUFFER_SIZE)
-		return false;
-	if (size > 0x7FFF)
+	_Static_assert(SHMEM_BUFFER_SIZE < BIT(15));
+	if (size >= BIT(15))
 		return false;
 
 	u8 *const dataBuffer = ARM_GetSHMEM()->dataBuffer.b;


### PR DESCRIPTION
During some testing I discovered changing SHMEM_BUFFER_SIZE from `2048` to `20480` broke I2C transfers.
This was due to size not being calculated correctly.

<details>
  <summary>Test code:</summary>
  
This was tested using onlinegdb.com:
  
  ```c
#include <stdio.h>
#include <stdint.h>

#define SHMEM_BUFFER_SIZE 20480
#define BIT(x) (1 << (x))

int main()
{
    uint32_t var = 0x01FF;
    var = var | (22 << 16); // "size" sent from arm9
    var = var | BIT(31); // Write operation
    uint32_t old_size = (var >> 16) % SHMEM_BUFFER_SIZE;
    uint32_t new_size = ((var >> 16) & 0x7FFF) % SHMEM_BUFFER_SIZE;

    printf("Old size: %01d, New size: %01d", old_size, new_size);

    return 0;
}
  ```
  
</details>

Output of the test code with `size` set to `22`:
`Old size: 12310, New size: 22`

The second commit adds a 15-bit size check to the arm9 side, rejecting commands early if size is too big.